### PR TITLE
Using GenServerHandle in handle_call and handle_cast to encapsulate internal communication

### DIFF
--- a/concurrency/src/tasks/time.rs
+++ b/concurrency/src/tasks/time.rs
@@ -9,7 +9,7 @@ use super::{GenServer, GenServerHandle};
 pub fn send_after<T>(
     period: Duration,
     mut handle: GenServerHandle<T>,
-    message: T::InMsg,
+    message: T::CastMsg,
 ) -> JoinHandle<()>
 where
     T: GenServer + 'static,

--- a/concurrency/src/threads/time.rs
+++ b/concurrency/src/threads/time.rs
@@ -9,7 +9,7 @@ use super::{GenServer, GenServerHandle};
 pub fn send_after<T>(
     period: Duration,
     mut handle: GenServerHandle<T>,
-    message: T::InMsg,
+    message: T::CastMsg,
 ) -> JoinHandle<()>
 where
     T: GenServer + 'static,

--- a/examples/bank/src/server.rs
+++ b/examples/bank/src/server.rs
@@ -41,7 +41,8 @@ impl Bank {
 }
 
 impl GenServer for Bank {
-    type InMsg = InMessage;
+    type CallMsg = InMessage;
+    type CastMsg = ();
     type OutMsg = MsgResult;
     type Error = BankError;
     type State = BankState;
@@ -52,19 +53,19 @@ impl GenServer for Bank {
 
     async fn handle_call(
         &mut self,
-        message: InMessage,
+        message: Self::CallMsg,
         _handle: &BankHandle,
         state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
         match message.clone() {
-            InMessage::New { who } => match state.get(&who) {
+            Self::CallMsg::New { who } => match state.get(&who) {
                 Some(_amount) => CallResponse::Reply(Err(BankError::AlreadyACustomer { who })),
                 None => {
                     state.insert(who.clone(), 0);
                     CallResponse::Reply(Ok(OutMessage::Welcome { who }))
                 }
             },
-            InMessage::Add { who, amount } => match state.get(&who) {
+            Self::CallMsg::Add { who, amount } => match state.get(&who) {
                 Some(current) => {
                     let new_amount = current + amount;
                     state.insert(who.clone(), new_amount);
@@ -75,7 +76,7 @@ impl GenServer for Bank {
                 }
                 None => CallResponse::Reply(Err(BankError::NotACustomer { who })),
             },
-            InMessage::Remove { who, amount } => match state.get(&who) {
+            Self::CallMsg::Remove { who, amount } => match state.get(&who) {
                 Some(current) => match current < &amount {
                     true => CallResponse::Reply(Err(BankError::InsufficientBalance {
                         who,
@@ -92,13 +93,13 @@ impl GenServer for Bank {
                 },
                 None => CallResponse::Reply(Err(BankError::NotACustomer { who })),
             },
-            InMessage::Stop => CallResponse::Stop(Ok(OutMessage::Stopped)),
+            Self::CallMsg::Stop => CallResponse::Stop(Ok(OutMessage::Stopped)),
         }
     }
 
     async fn handle_cast(
         &mut self,
-        _message: InMessage,
+        _message: Self::CastMsg,
         _handle: &BankHandle,
         _state: &mut Self::State,
     ) -> CastResponse {

--- a/examples/bank_threads/src/server.rs
+++ b/examples/bank_threads/src/server.rs
@@ -37,7 +37,8 @@ impl Bank {
 }
 
 impl GenServer for Bank {
-    type InMsg = InMessage;
+    type CallMsg = InMessage;
+    type CastMsg = ();
     type OutMsg = MsgResult;
     type Error = BankError;
     type State = BankState;
@@ -48,7 +49,7 @@ impl GenServer for Bank {
 
     fn handle_call(
         &mut self,
-        message: InMessage,
+        message: Self::CallMsg,
         _handle: &BankHandle,
         state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
@@ -94,7 +95,7 @@ impl GenServer for Bank {
 
     fn handle_cast(
         &mut self,
-        _message: InMessage,
+        _message: Self::CastMsg,
         _handle: &BankHandle,
         _state: &mut Self::State,
     ) -> CastResponse {

--- a/examples/name_server/src/server.rs
+++ b/examples/name_server/src/server.rs
@@ -26,7 +26,8 @@ impl NameServer {
 }
 
 impl GenServer for NameServer {
-    type InMsg = InMessage;
+    type CallMsg = InMessage;
+    type CastMsg = ();
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = NameServerState;
@@ -37,16 +38,16 @@ impl GenServer for NameServer {
 
     async fn handle_call(
         &mut self,
-        message: InMessage,
+        message: Self::CallMsg,
         _handle: &NameServerHandle,
         state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
         match message.clone() {
-            Self::InMsg::Add { key, value } => {
+            Self::CallMsg::Add { key, value } => {
                 state.insert(key, value);
                 CallResponse::Reply(Self::OutMsg::Ok)
             }
-            Self::InMsg::Find { key } => match state.get(&key) {
+            Self::CallMsg::Find { key } => match state.get(&key) {
                 Some(value) => CallResponse::Reply(Self::OutMsg::Found {
                     value: value.to_string(),
                 }),
@@ -57,7 +58,7 @@ impl GenServer for NameServer {
 
     async fn handle_cast(
         &mut self,
-        _message: InMessage,
+        _message: Self::CastMsg,
         _handle: &NameServerHandle,
         _state: &mut Self::State,
     ) -> CastResponse {

--- a/examples/name_server_with_error/src/server.rs
+++ b/examples/name_server_with_error/src/server.rs
@@ -29,7 +29,8 @@ impl NameServer {
 }
 
 impl GenServer for NameServer {
-    type InMsg = InMessage;
+    type CallMsg = InMessage;
+    type CastMsg = ();
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = NameServerState;
@@ -40,12 +41,12 @@ impl GenServer for NameServer {
 
     async fn handle_call(
         &mut self,
-        message: InMessage,
+        message: Self::CallMsg,
         _handle: &NameServerHandle,
         state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
         match message.clone() {
-            Self::InMsg::Add { key, value } => {
+            Self::CallMsg::Add { key, value } => {
                 state.insert(key.clone(), value);
                 if key == "error" {
                     panic!("error!")
@@ -53,7 +54,7 @@ impl GenServer for NameServer {
                     CallResponse::Reply(Self::OutMsg::Ok)
                 }
             }
-            Self::InMsg::Find { key } => match state.get(&key) {
+            Self::CallMsg::Find { key } => match state.get(&key) {
                 Some(value) => CallResponse::Reply(Self::OutMsg::Found {
                     value: value.to_string(),
                 }),
@@ -64,7 +65,7 @@ impl GenServer for NameServer {
 
     async fn handle_cast(
         &mut self,
-        _message: InMessage,
+        _message: Self::CastMsg,
         _handle: &NameServerHandle,
         _state: &mut Self::State,
     ) -> CastResponse {

--- a/examples/updater/src/server.rs
+++ b/examples/updater/src/server.rs
@@ -25,7 +25,8 @@ impl UpdaterServer {
 }
 
 impl GenServer for UpdaterServer {
-    type InMsg = InMessage;
+    type CallMsg = ();
+    type CastMsg = InMessage;
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = UpdateServerState;
@@ -36,7 +37,7 @@ impl GenServer for UpdaterServer {
 
     async fn handle_call(
         &mut self,
-        _message: InMessage,
+        _message: Self::CallMsg,
         _handle: &UpdateServerHandle,
         _state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
@@ -45,12 +46,12 @@ impl GenServer for UpdaterServer {
 
     async fn handle_cast(
         &mut self,
-        message: InMessage,
+        message: Self::CastMsg,
         handle: &UpdateServerHandle,
         state: &mut Self::State,
     ) -> CastResponse {
         match message {
-            Self::InMsg::Check => {
+            Self::CastMsg::Check => {
                 send_after(state.periodicity, handle.clone(), InMessage::Check);
                 let url = state.url.clone();
                 tracing::info!("Fetching: {url}");

--- a/examples/updater_threads/src/server.rs
+++ b/examples/updater_threads/src/server.rs
@@ -26,7 +26,8 @@ impl UpdaterServer {
 }
 
 impl GenServer for UpdaterServer {
-    type InMsg = InMessage;
+    type CallMsg = ();
+    type CastMsg = InMessage;
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = UpdateServerState;
@@ -37,7 +38,7 @@ impl GenServer for UpdaterServer {
 
     fn handle_call(
         &mut self,
-        _message: InMessage,
+        _message: Self::CallMsg,
         _handle: &UpdateServerHandle,
         _state: &mut Self::State,
     ) -> CallResponse<Self::OutMsg> {
@@ -46,12 +47,12 @@ impl GenServer for UpdaterServer {
 
     fn handle_cast(
         &mut self,
-        message: InMessage,
+        message: Self::CastMsg,
         handle: &UpdateServerHandle,
         state: &mut Self::State,
     ) -> CastResponse {
         match message {
-            Self::InMsg::Check => {
+            Self::CastMsg::Check => {
                 send_after(state.periodicity, handle.clone(), InMessage::Check);
                 let url = state.url.clone();
                 tracing::info!("Fetching: {url}");


### PR DESCRIPTION
Instead of receiving the `Sender` in `handle_call` and `handle_cast` callbacks, we send the `GenServerHandle`. So any client code can do `handle.cast(...)` or `handle.call(...)` using that handler, instead of explicitly sending into the channel via the `Sender`