### PR TITLE
feature: added blocking start for genservers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "blocking_genserver"
+version = "0.1.0"
+dependencies = [
+ "spawned-concurrency",
+ "spawned-rt",
+ "tracing",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "examples/ping_pong",
     "examples/ping_pong_threads",
     "examples/updater",
-    "examples/updater_threads",
+    "examples/updater_threads", "examples/blocking_genserver",
 ]
 
 [workspace.dependencies]

--- a/concurrency/src/threads/gen_server.rs
+++ b/concurrency/src/threads/gen_server.rs
@@ -98,6 +98,12 @@ where
         GenServerHandle::new(initial_state)
     }
 
+    /// We copy the same interface than threads, but all threads can work
+    /// while blocking by default
+    fn start_blocking(initial_state: Self::State) -> GenServerHandle<Self> {
+        GenServerHandle::new(initial_state)
+    }
+
     fn run(
         &mut self,
         handle: &GenServerHandle<Self>,

--- a/examples/blocking_genserver/Cargo.toml
+++ b/examples/blocking_genserver/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "blocking_genserver"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+spawned-rt = { workspace = true }
+spawned-concurrency = { workspace = true }
+tracing = { workspace = true }
+
+[[bin]]
+name = "blocking_genserver"
+path = "main.rs"

--- a/examples/blocking_genserver/main.rs
+++ b/examples/blocking_genserver/main.rs
@@ -1,0 +1,139 @@
+use spawned_rt::tasks as rt;
+use std::time::Duration;
+use std::{process::exit, thread};
+
+use spawned_concurrency::tasks::{
+    CallResponse, CastResponse, GenServer, GenServerHandle, send_after,
+};
+
+// We test a scenario with a badly behaved task
+struct BadlyBehavedTask;
+
+#[derive(Clone)]
+pub enum InMessage {
+    GetCount,
+    Stop,
+}
+#[derive(Clone)]
+pub enum OutMsg {
+    Count(u64),
+}
+
+impl GenServer for BadlyBehavedTask {
+    type CallMsg = InMessage;
+    type CastMsg = ();
+    type OutMsg = ();
+    type State = ();
+    type Error = ();
+
+    fn new() -> Self {
+        Self {}
+    }
+
+    async fn handle_call(
+        &mut self,
+        _: Self::CallMsg,
+        _: &GenServerHandle<Self>,
+        _: &mut Self::State,
+    ) -> CallResponse<Self::OutMsg> {
+        CallResponse::Stop(())
+    }
+
+    async fn handle_cast(
+        &mut self,
+        _: Self::CastMsg,
+        _: &GenServerHandle<Self>,
+        _: &mut Self::State,
+    ) -> CastResponse {
+        rt::sleep(Duration::from_millis(20)).await;
+        loop {
+            println!("{:?}: bad still alive", thread::current().id());
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+struct WellBehavedTask;
+
+#[derive(Clone)]
+struct CountState {
+    pub count: u64,
+}
+
+impl GenServer for WellBehavedTask {
+    type CallMsg = InMessage;
+    type CastMsg = ();
+    type OutMsg = OutMsg;
+    type State = CountState;
+    type Error = ();
+
+    fn new() -> Self {
+        Self {}
+    }
+
+    async fn handle_call(
+        &mut self,
+        message: Self::CallMsg,
+        _: &GenServerHandle<Self>,
+        state: &mut Self::State,
+    ) -> CallResponse<Self::OutMsg> {
+        match message {
+            InMessage::GetCount => CallResponse::Reply(OutMsg::Count(state.count)),
+            InMessage::Stop => CallResponse::Stop(OutMsg::Count(state.count)),
+        }
+    }
+
+    async fn handle_cast(
+        &mut self,
+        _: Self::CastMsg,
+        handle: &GenServerHandle<Self>,
+        state: &mut Self::State,
+    ) -> CastResponse {
+        state.count += 1;
+        println!("{:?}: good still alive", thread::current().id());
+        send_after(Duration::from_millis(100), handle.to_owned(), ());
+        CastResponse::NoReply
+    }
+}
+
+/*     #[test]
+pub fn badly_behaved_non_thread() {
+    rt::run(async move {
+        let mut badboy = BadlyBehavedTask::start(());
+        let _ = badboy.cast(()).await;
+        let mut goodboy = WellBehavedTask::start(CountState{count: 0});
+        let _ = goodboy.cast(()).await;
+        rt::sleep(Duration::from_secs(1)).await;
+        let count = goodboy.call(InMessage::GetCount).await.unwrap();
+
+        match count {
+            OutMsg::Count(num) => {x
+                assert!(num == 10);
+            }
+        }
+    })
+} */
+
+/// Example of start_blocking to fix issues #8 https://github.com/lambdaclass/spawned/issues/8
+/// Tasks that block can block the entire tokio runtime (and other cooperative multitasking models)
+/// To fix this we implement start_blocking, which under the hood launches a new thread to deal with the issue
+pub fn main() {
+    rt::run(async move {
+        // If we change BadlyBehavedTask to start instead, it can stop the entire program
+        let mut badboy = BadlyBehavedTask::start_blocking(());
+        let _ = badboy.cast(()).await;
+        let mut goodboy = WellBehavedTask::start(CountState { count: 0 });
+        let _ = goodboy.cast(()).await;
+        rt::sleep(Duration::from_secs(1)).await;
+        let count = goodboy.call(InMessage::GetCount).await.unwrap();
+
+        match count {
+            OutMsg::Count(num) => {
+                assert!(num == 10);
+            }
+        }
+
+        goodboy.call(InMessage::Stop).await.unwrap();
+        exit(0);
+    })
+}

--- a/rt/src/tasks/mod.rs
+++ b/rt/src/tasks/mod.rs
@@ -9,12 +9,14 @@
 
 mod tokio;
 
+use ::tokio::runtime::Handle;
+
 use crate::tracing::init_tracing;
 
 pub use crate::tasks::tokio::mpsc;
 pub use crate::tasks::tokio::oneshot;
 pub use crate::tasks::tokio::sleep;
-pub use crate::tasks::tokio::{spawn, JoinHandle, Runtime};
+pub use crate::tasks::tokio::{spawn, spawn_blocking, JoinHandle, Runtime};
 use std::future::Future;
 
 pub fn run<F: Future>(future: F) -> F::Output {
@@ -22,4 +24,8 @@ pub fn run<F: Future>(future: F) -> F::Output {
 
     let rt = Runtime::new().unwrap();
     rt.block_on(future)
+}
+
+pub fn block_on<F: Future>(future: F) -> F::Output {
+    Handle::current().block_on(future)
 }

--- a/rt/src/tasks/tokio/mod.rs
+++ b/rt/src/tasks/tokio/mod.rs
@@ -4,6 +4,6 @@ pub mod oneshot;
 
 pub use tokio::{
     runtime::Runtime,
-    task::{spawn, JoinHandle},
+    task::{spawn, spawn_blocking, JoinHandle},
     time::sleep,
 };

--- a/rt/src/threads/mod.rs
+++ b/rt/src/threads/mod.rs
@@ -20,3 +20,12 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     let rt = Runtime::new().unwrap();
     rt.block_on(future)
 }
+
+/// Spawn blocking is the same as spawn for pure threaded usage.
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    spawn(f)
+}


### PR DESCRIPTION
**Motivation**

In the tokio runtime (and other cooperative multitasking models) a single blocking task may stop executions or degrade performance of the entire program, as detailed in issue #8.

**Description**

This PR adds a method `start_blocking` to the Genserver that launches the task in it's own thread, stopping from blocking. This is the same api both on concurrency and threads submodules, although threads already does this for every task.

Closes issue #8