### PR TITLE
Revert "Removed the requirement of implementing Clone on CallMsg and CastMsg"

### DIFF
--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -105,8 +105,8 @@ pub trait GenServer
 where
     Self: Send + Sized,
 {
-    type CallMsg: Send + Sized + Sync;
-    type CastMsg: Send + Sized + Sync;
+    type CallMsg: Clone + Send + Sized + Sync;
+    type CastMsg: Clone + Send + Sized + Sync;
     type OutMsg: Send + Sized;
     type State: Clone + Send;
     type Error: Debug + Send;

--- a/concurrency/src/tasks/time.rs
+++ b/concurrency/src/tasks/time.rs
@@ -27,7 +27,7 @@ where
             Box::pin(cloned_token.cancelled()),
             Box::pin(async {
                 rt::sleep(period).await;
-                let _ = handle.cast(message).await;
+                let _ = handle.cast(message.clone()).await;
             }),
         )
         .await;
@@ -46,7 +46,6 @@ pub fn send_interval<T>(
 ) -> TimerHandle
 where
     T: GenServer + 'static,
-    T::CastMsg: Clone,
 {
     let cancellation_token = CancellationToken::new();
     let cloned_token = cancellation_token.clone();

--- a/concurrency/src/threads/gen_server.rs
+++ b/concurrency/src/threads/gen_server.rs
@@ -83,8 +83,8 @@ pub trait GenServer
 where
     Self: Send + Sized,
 {
-    type CallMsg: Send + Sized;
-    type CastMsg: Send + Sized;
+    type CallMsg: Clone + Send + Sized;
+    type CastMsg: Clone + Send + Sized;
     type OutMsg: Send + Sized;
     type State: Clone + Send;
     type Error: Debug;

--- a/concurrency/src/threads/time.rs
+++ b/concurrency/src/threads/time.rs
@@ -41,7 +41,6 @@ pub fn send_interval<T>(
 ) -> TimerHandle
 where
     T: GenServer + 'static,
-    T::CastMsg: Clone,
 {
     let cancellation_token = CancellationToken::new();
     let mut cloned_token = cancellation_token.clone();


### PR DESCRIPTION
Reverts lambdaclass/spawned#14

It's not a great idea to require Clone for some enum variants only, as it will push the Clone requirement for the whole `Cast/CallMessage` enums.

GenServer messages should be clonable as we want to work on the premise that it's safer to copy/clone than memory sharing.