### PR TITLE
Crate release workflows

### DIFF
--- a/.github/workflows/spawned-concurrency-release.yaml
+++ b/.github/workflows/spawned-concurrency-release.yaml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  crates-publish:
+    runs-on: ubuntu-latest
+    environment: crates-release-prod
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Set Up Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 #1.10.1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Publish Crate
+        run: cargo publish --package spawned-concurrency --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/spawned-rt-release.yaml
+++ b/.github/workflows/spawned-rt-release.yaml
@@ -1,0 +1,19 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  crates-publish:
+    runs-on: ubuntu-latest
+    environment: crates-release-prod
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
+      - name: Set Up Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 #1.10.1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Publish Crate
+        run: cargo publish --package spawned-rt --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 resolver = "3"
+
 members = [
     "rt",
+    "concurrency",
     "examples/bank",
     "examples/bank_threads",
     "examples/name_server",
@@ -14,7 +16,7 @@ members = [
 ]
 
 [workspace.dependencies]
-spawned-rt = { version = "0.1.0", path = "rt" }
-spawned-concurrency = { version = "0.1.0", path = "concurrency" }
+spawned-rt = { path = "rt" }
+spawned-concurrency = { path = "concurrency" }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -2,6 +2,8 @@
 name = "spawned-concurrency"
 version = "0.1.0"
 edition = "2021"
+description = "Spawned Concurrency"
+license = "MIT"
 
 [dependencies]
 spawned-rt = { workspace = true }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -2,6 +2,8 @@
 name = "spawned-rt"
 version = "0.1.0"
 edition = "2021"
+description = "Spawned Runtime"
+license = "MIT"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Modify workspace to add CI jobs capable of releasing to crates.io when requested:
- Two separate jobs, one for `spawned-rt` and another for `spawned-concurrency`.
- Release version will be matched by `package.version` specified in toml.