### PR TITLE
Add `Debug` to `GenServerHandle`

### DIFF
--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -6,6 +6,7 @@ use std::{fmt::Debug, future::Future, panic::AssertUnwindSafe};
 
 use crate::error::GenServerError;
 
+#[derive(Debug)]
 pub struct GenServerHandle<G: GenServer + 'static> {
     pub tx: mpsc::Sender<GenServerInMsg<G>>,
     /// Cancellation token to stop the GenServer


### PR DESCRIPTION
Derive was removed, but should be added again for debugging purposes in external crates