### PR TITLE
Make GenServers to implement Default

### DIFF
--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -120,7 +120,7 @@ pub enum CastResponse<G: GenServer> {
 
 pub trait GenServer
 where
-    Self: Send + Sized,
+    Self: Default + Send + Sized,
 {
     type CallMsg: Clone + Send + Sized + Sync;
     type CastMsg: Clone + Send + Sized + Sync;
@@ -128,7 +128,9 @@ where
     type State: Clone + Send;
     type Error: Debug + Send;
 
-    fn new() -> Self;
+    fn new() -> Self {
+        Self::default()
+    }
 
     fn start(initial_state: Self::State) -> GenServerHandle<Self> {
         GenServerHandle::new(initial_state)
@@ -307,6 +309,8 @@ mod tests {
     use super::*;
     use crate::tasks::send_after;
     use std::{thread, time::Duration};
+
+    #[derive(Default)]
     struct BadlyBehavedTask;
 
     #[derive(Clone)]
@@ -325,10 +329,6 @@ mod tests {
         type OutMsg = ();
         type State = ();
         type Error = ();
-
-        fn new() -> Self {
-            Self {}
-        }
 
         async fn handle_call(
             &mut self,
@@ -351,6 +351,7 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
     struct WellBehavedTask;
 
     #[derive(Clone)]
@@ -364,10 +365,6 @@ mod tests {
         type OutMsg = OutMsg;
         type State = CountState;
         type Error = ();
-
-        fn new() -> Self {
-            Self {}
-        }
 
         async fn handle_call(
             &mut self,

--- a/concurrency/src/tasks/stream_tests.rs
+++ b/concurrency/src/tasks/stream_tests.rs
@@ -8,6 +8,7 @@ use crate::tasks::{
 
 type SummatoryHandle = GenServerHandle<Summatory>;
 
+#[derive(Default)]
 struct Summatory;
 
 type SummatoryState = u16;
@@ -31,10 +32,6 @@ impl GenServer for Summatory {
     type OutMsg = SummatoryOutMessage;
     type State = SummatoryState;
     type Error = ();
-
-    fn new() -> Self {
-        Self
-    }
 
     async fn handle_cast(
         &mut self,

--- a/concurrency/src/tasks/timer_tests.rs
+++ b/concurrency/src/tasks/timer_tests.rs
@@ -28,6 +28,7 @@ enum RepeaterOutMessage {
     Count(i32),
 }
 
+#[derive(Default)]
 struct Repeater;
 
 impl Repeater {
@@ -52,10 +53,6 @@ impl GenServer for Repeater {
     type OutMsg = RepeaterOutMessage;
     type State = RepeaterState;
     type Error = ();
-
-    fn new() -> Self {
-        Self
-    }
 
     async fn init(
         &mut self,
@@ -157,6 +154,7 @@ enum DelayedOutMessage {
     Count(i32),
 }
 
+#[derive(Default)]
 struct Delayed;
 
 impl Delayed {
@@ -178,10 +176,6 @@ impl GenServer for Delayed {
     type OutMsg = DelayedOutMessage;
     type State = DelayedState;
     type Error = ();
-
-    fn new() -> Self {
-        Self
-    }
 
     async fn handle_call(
         &mut self,

--- a/concurrency/src/threads/gen_server.rs
+++ b/concurrency/src/threads/gen_server.rs
@@ -83,7 +83,7 @@ pub enum CastResponse<G: GenServer> {
 
 pub trait GenServer
 where
-    Self: Send + Sized,
+    Self: Default + Send + Sized,
 {
     type CallMsg: Clone + Send + Sized;
     type CastMsg: Clone + Send + Sized;
@@ -91,7 +91,9 @@ where
     type State: Clone + Send;
     type Error: Debug;
 
-    fn new() -> Self;
+    fn new() -> Self {
+        Self::default()
+    }
 
     fn start(initial_state: Self::State) -> GenServerHandle<Self> {
         GenServerHandle::new(initial_state)

--- a/concurrency/src/threads/timer_tests.rs
+++ b/concurrency/src/threads/timer_tests.rs
@@ -28,6 +28,7 @@ enum RepeaterOutMessage {
     Count(i32),
 }
 
+#[derive(Default)]
 struct Repeater;
 
 impl Repeater {
@@ -46,10 +47,6 @@ impl GenServer for Repeater {
     type OutMsg = RepeaterOutMessage;
     type State = RepeaterState;
     type Error = ();
-
-    fn new() -> Self {
-        Self
-    }
 
     fn init(
         &mut self,
@@ -147,6 +144,7 @@ enum DelayedOutMessage {
     Count(i32),
 }
 
+#[derive(Default)]
 struct Delayed;
 
 impl Delayed {
@@ -161,10 +159,6 @@ impl GenServer for Delayed {
     type OutMsg = DelayedOutMessage;
     type State = DelayedState;
     type Error = ();
-
-    fn new() -> Self {
-        Self
-    }
 
     fn handle_call(
         &mut self,

--- a/examples/bank/src/server.rs
+++ b/examples/bank/src/server.rs
@@ -11,6 +11,7 @@ type MsgResult = Result<OutMessage, BankError>;
 type BankHandle = GenServerHandle<Bank>;
 type BankState = HashMap<String, i32>;
 
+#[derive(Default)]
 pub struct Bank {}
 
 impl Bank {
@@ -49,10 +50,6 @@ impl GenServer for Bank {
     type OutMsg = MsgResult;
     type Error = BankError;
     type State = BankState;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     // Initializing "main" account with 1000 in balance to test init() callback.
     async fn init(

--- a/examples/bank_threads/src/server.rs
+++ b/examples/bank_threads/src/server.rs
@@ -11,6 +11,7 @@ type MsgResult = Result<OutMessage, BankError>;
 type BankHandle = GenServerHandle<Bank>;
 type BankState = HashMap<String, i32>;
 
+#[derive(Default)]
 pub struct Bank {}
 
 impl Bank {
@@ -45,10 +46,6 @@ impl GenServer for Bank {
     type OutMsg = MsgResult;
     type Error = BankError;
     type State = BankState;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     // Initializing "main" account with 1000 in balance to test init() callback.
     fn init(

--- a/examples/blocking_genserver/main.rs
+++ b/examples/blocking_genserver/main.rs
@@ -6,7 +6,8 @@ use spawned_concurrency::tasks::{
     CallResponse, CastResponse, GenServer, GenServerHandle, send_after,
 };
 
-// We test a scenario with a badly behaved task
+// We test a scenario with a badly behaved task#[derive(Default)]
+#[derive(Default)]
 struct BadlyBehavedTask;
 
 #[derive(Clone)]
@@ -25,10 +26,6 @@ impl GenServer for BadlyBehavedTask {
     type OutMsg = ();
     type State = ();
     type Error = ();
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_call(
         &mut self,
@@ -53,6 +50,7 @@ impl GenServer for BadlyBehavedTask {
     }
 }
 
+#[derive(Default)]
 struct WellBehavedTask;
 
 #[derive(Clone)]
@@ -66,10 +64,6 @@ impl GenServer for WellBehavedTask {
     type OutMsg = OutMsg;
     type State = CountState;
     type Error = ();
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_call(
         &mut self,

--- a/examples/name_server/src/server.rs
+++ b/examples/name_server/src/server.rs
@@ -10,6 +10,7 @@ use crate::messages::{NameServerInMessage as InMessage, NameServerOutMessage as 
 type NameServerHandle = GenServerHandle<NameServer>;
 type NameServerState = HashMap<String, String>;
 
+#[derive(Default)]
 pub struct NameServer {}
 
 impl NameServer {
@@ -34,10 +35,6 @@ impl GenServer for NameServer {
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = NameServerState;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     async fn handle_call(
         &mut self,

--- a/examples/name_server_with_error/src/server.rs
+++ b/examples/name_server_with_error/src/server.rs
@@ -11,6 +11,7 @@ use crate::messages::{NameServerInMessage as InMessage, NameServerOutMessage as 
 type NameServerHandle = GenServerHandle<NameServer>;
 type NameServerState = HashMap<String, String>;
 
+#[derive(Default)]
 pub struct NameServer {}
 
 impl NameServer {
@@ -36,10 +37,6 @@ impl GenServer for NameServer {
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = NameServerState;
-
-    fn new() -> Self {
-        NameServer {}
-    }
 
     async fn handle_call(
         &mut self,

--- a/examples/updater/src/server.rs
+++ b/examples/updater/src/server.rs
@@ -16,6 +16,7 @@ pub struct UpdateServerState {
     pub periodicity: Duration,
     pub timer_token: Option<CancellationToken>,
 }
+#[derive(Default)]
 pub struct UpdaterServer {}
 
 impl GenServer for UpdaterServer {
@@ -24,10 +25,6 @@ impl GenServer for UpdaterServer {
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = UpdateServerState;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     // Initializing GenServer to start periodic checks.
     async fn init(

--- a/examples/updater_threads/src/server.rs
+++ b/examples/updater_threads/src/server.rs
@@ -15,6 +15,7 @@ pub struct UpdateServerState {
     pub url: String,
     pub periodicity: Duration,
 }
+#[derive(Default)]
 pub struct UpdaterServer {}
 
 impl GenServer for UpdaterServer {
@@ -23,10 +24,6 @@ impl GenServer for UpdaterServer {
     type OutMsg = OutMessage;
     type Error = std::fmt::Error;
     type State = UpdateServerState;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     // Initializing GenServer to start periodic checks.
     fn init(


### PR DESCRIPTION
This will avoid requiring all the
```rust
        fn new() -> Self {
            Self {}
        }
```
declarations on every GenServer implementation.