### PR TITLE
Bump version for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "spawned-concurrency"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "futures",
  "spawned-rt",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "spawned-rt"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "crossbeam",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
Bump `toml` version to `0.1.7` to release new `timeout` feature.