### PR TITLE
Fix: remove cloning from `GenServer::run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "spawned-concurrency"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "spawned-rt",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "spawned-rt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossbeam",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,6 @@ tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
Cloning of state is prone to failure, for example we had streams being dropped/closed due to being cloned inside of our `run` function.