### PR TITLE
feature: add Result on `GenServer` start

### DIFF
--- a/concurrency/src/tasks/stream_tests.rs
+++ b/concurrency/src/tasks/stream_tests.rs
@@ -73,7 +73,7 @@ fn message_builder(value: u8) -> SummatoryCastMessage {
 pub fn test_sum_numbers_from_stream() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
-        let mut summatory_handle = Summatory::new(0).start();
+        let mut summatory_handle = Summatory::new(0).start().unwrap();
         let stream = tokio_stream::iter(vec![1u8, 2, 3, 4, 5].into_iter().map(Ok::<u8, ()>));
 
         spawn_listener(summatory_handle.clone(), message_builder, stream);
@@ -90,7 +90,7 @@ pub fn test_sum_numbers_from_stream() {
 pub fn test_sum_numbers_from_channel() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
-        let mut summatory_handle = Summatory::new(0).start();
+        let mut summatory_handle = Summatory::new(0).start().unwrap();
         let (tx, rx) = spawned_rt::tasks::mpsc::channel::<Result<u8, ()>>();
 
         // Spawn a task to send numbers to the channel
@@ -118,7 +118,7 @@ pub fn test_sum_numbers_from_channel() {
 pub fn test_sum_numbers_from_broadcast_channel() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
-        let mut summatory_handle = Summatory::new(0).start();
+        let mut summatory_handle = Summatory::new(0).start().unwrap();
         let (tx, rx) = tokio::sync::broadcast::channel::<u8>(5);
 
         // Spawn a task to send numbers to the channel
@@ -148,7 +148,7 @@ pub fn test_stream_cancellation() {
 
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
-        let mut summatory_handle = Summatory::new(0).start();
+        let mut summatory_handle = Summatory::new(0).start().unwrap();
         let (tx, rx) = spawned_rt::tasks::mpsc::channel::<Result<u8, ()>>();
 
         // Spawn a task to send numbers to the channel

--- a/concurrency/src/tasks/timer_tests.rs
+++ b/concurrency/src/tasks/timer_tests.rs
@@ -102,7 +102,7 @@ pub fn test_send_interval_and_cancellation() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
         // Start a Repeater
-        let mut repeater = Repeater::new(0).start();
+        let mut repeater = Repeater::new(0).start().unwrap();
 
         // Wait for 1 second
         rt::sleep(Duration::from_secs(1)).await;
@@ -210,7 +210,7 @@ pub fn test_send_after_and_cancellation() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
         // Start a Delayed
-        let mut repeater = Delayed::new(0).start();
+        let mut repeater = Delayed::new(0).start().unwrap();
 
         // Set a just once timed message
         let _ = send_after(
@@ -254,7 +254,7 @@ pub fn test_send_after_gen_server_teardown() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
         // Start a Delayed
-        let mut repeater = Delayed::new(0).start();
+        let mut repeater = Delayed::new(0).start().unwrap();
 
         // Set a just once timed message
         let _ = send_after(

--- a/examples/bank/src/main.rs
+++ b/examples/bank/src/main.rs
@@ -30,7 +30,7 @@ use spawned_rt::tasks as rt;
 fn main() {
     rt::run(async {
         // Starting the bank
-        let mut name_server = Bank::new().start();
+        let mut name_server = Bank::new().start().unwrap();
 
         // Testing initial balance for "main" account
         let result = Bank::withdraw(&mut name_server, "main".to_string(), 15).await;

--- a/examples/blocking_genserver/main.rs
+++ b/examples/blocking_genserver/main.rs
@@ -97,9 +97,9 @@ impl GenServer for WellBehavedTask {
 pub fn main() {
     rt::run(async move {
         // If we change BadlyBehavedTask to start instead, it can stop the entire program
-        let mut badboy = BadlyBehavedTask::new().start_blocking();
+        let mut badboy = BadlyBehavedTask::new().start_blocking().unwrap();
         let _ = badboy.cast(()).await;
-        let mut goodboy = WellBehavedTask::new(0).start();
+        let mut goodboy = WellBehavedTask::new(0).start().unwrap();
         let _ = goodboy.cast(()).await;
         rt::sleep(Duration::from_secs(1)).await;
         let count = goodboy.call(InMessage::GetCount).await.unwrap();

--- a/examples/name_server/src/main.rs
+++ b/examples/name_server/src/main.rs
@@ -21,7 +21,7 @@ use spawned_rt::tasks as rt;
 
 fn main() {
     rt::run(async {
-        let mut name_server = NameServer::new().start();
+        let mut name_server = NameServer::new().start().unwrap();
 
         let result =
             NameServer::add(&mut name_server, "Joe".to_string(), "At Home".to_string()).await;

--- a/examples/name_server_with_error/src/main.rs
+++ b/examples/name_server_with_error/src/main.rs
@@ -26,7 +26,8 @@ fn main() {
         let mut name_server = NameServer {
             inner: HashMap::new(),
         }
-        .start();
+        .start()
+        .unwrap();
 
         let result =
             NameServer::add(&mut name_server, "Joe".to_string(), "At Home".to_string()).await;

--- a/examples/updater/src/main.rs
+++ b/examples/updater/src/main.rs
@@ -19,7 +19,8 @@ fn main() {
             "https://httpbin.org/ip".to_string(),
             Duration::from_millis(1000),
         )
-        .start();
+        .start()
+        .unwrap();
 
         // giving it some time before ending
         thread::sleep(Duration::from_secs(10));


### PR DESCRIPTION
Our current implementation of `GenServers` consists of `start`ing the actors without ever checking if at least they began properly. This PR attemps to fix that so the _spawner_ can at least guarantee that its child had a proper instantiation.

Insipiration on this PR comes from #39, which should be merged beforehand.