### PR TITLE
Fix error on spawn_listener

### DIFF
--- a/concurrency/src/tasks/stream.rs
+++ b/concurrency/src/tasks/stream.rs
@@ -38,7 +38,7 @@ where
                         // Stream has new data, but failed to extract the Item,
                         // probably due to decoding problems.
                         Some(Err(e)) => {
-                            // log the error but keep listening for more valid Items
+                            // log the error but keep listener alive for more valid Items
                             tracing::error!("Error processing stream: {e:?}");
                         }
                         None => {

--- a/concurrency/src/tasks/stream.rs
+++ b/concurrency/src/tasks/stream.rs
@@ -27,6 +27,7 @@ where
             Box::pin(async {
                 loop {
                     match stream.next().await {
+                        // Stream has a new valid Item
                         Some(Ok(i)) => match handle.cast(message_builder(i)).await {
                             Ok(_) => tracing::trace!("Message sent successfully"),
                             Err(e) => {
@@ -34,8 +35,11 @@ where
                                 break;
                             }
                         },
+                        // Stream has new data, but failed to extract the Item,
+                        // probably due to decoding problems.
                         Some(Err(e)) => {
-                            tracing::trace!("Error in stream: {e:?}");
+                            // log the error but keep listening for more valid Items
+                            tracing::error!("Error processing stream: {e:?}");
                         }
                         None => {
                             tracing::trace!("Stream finished");

--- a/concurrency/src/tasks/stream.rs
+++ b/concurrency/src/tasks/stream.rs
@@ -35,8 +35,7 @@ where
                             }
                         },
                         Some(Err(e)) => {
-                            tracing::trace!("Received Error in msg {e:?}");
-                            break;
+                            tracing::trace!("Error in stream: {e:?}");
                         }
                         None => {
                             tracing::trace!("Stream finished");

--- a/concurrency/src/tasks/stream_tests.rs
+++ b/concurrency/src/tasks/stream_tests.rs
@@ -194,7 +194,7 @@ pub fn test_stream_skipping_decoding_error() {
     runtime.block_on(async move {
         let mut summatory_handle = Summatory::new(0).start();
         let stream = tokio_stream::iter(vec![
-            Ok::<u8, Error>(1u8),
+            Ok(1),
             Ok(2),
             Ok(3),
             Err(Error::other("oh no!")),

--- a/concurrency/src/tasks/stream_tests.rs
+++ b/concurrency/src/tasks/stream_tests.rs
@@ -1,13 +1,8 @@
-use std::{
-    io::{Error, ErrorKind},
-    time::Duration,
-};
-
-use spawned_rt::tasks::{self as rt, BroadcastStream, ReceiverStream};
-
 use crate::tasks::{
     send_after, stream::spawn_listener, CallResponse, CastResponse, GenServer, GenServerHandle,
 };
+use spawned_rt::tasks::{self as rt, BroadcastStream, ReceiverStream};
+use std::{io::Error, time::Duration};
 
 type SummatoryHandle = GenServerHandle<Summatory>;
 
@@ -198,17 +193,14 @@ pub fn test_stream_skipping_decoding_error() {
     let runtime = rt::Runtime::new().unwrap();
     runtime.block_on(async move {
         let mut summatory_handle = Summatory::new(0).start();
-        let stream = tokio_stream::iter(
-            vec![
-                Ok::<u8, Error>(1u8),
-                Ok(2),
-                Ok(3),
-                Err(Error::new(ErrorKind::Other, "Oh no")),
-                Ok(4),
-                Ok(5),
-            ]
-            .into_iter(),
-        );
+        let stream = tokio_stream::iter(vec![
+            Ok::<u8, Error>(1u8),
+            Ok(2),
+            Ok(3),
+            Err(Error::other("oh no!")),
+            Ok(4),
+            Ok(5),
+        ]);
 
         spawn_listener(summatory_handle.clone(), message_builder, stream);
 


### PR DESCRIPTION
When using `spawn_listener` the stream is being consumed retrieving one `Result<I, E>` each time. 

When the `Result` is `Ok(I)` it gets processed, but if it is an `Err(E)` the listener currently is stopped, preventing it from processing more data. The `Error` may be caused by invalid data from the stream (causing a `DecodingError`), but we don't want to end the listener. 

With this change, we just discard the invalid package and keep the listener alive for more items.