### PR TITLE
feat: bind warn-on-block to debug-assertions

### DIFF
--- a/concurrency/Cargo.toml
+++ b/concurrency/Cargo.toml
@@ -10,16 +10,9 @@ spawned-rt = { workspace = true }
 tracing = { workspace = true }
 futures = "0.3.1"
 thiserror = "2.0.12"
-pin-project-lite = { version = "0.2", optional = true }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 # This tokio imports are only used in tests, we should not use them in the library code.
 tokio-stream = { version = "0.1.17" }
 tokio = { version = "1", features = ["full"] }
-
-[lib]
-path = "./src/lib.rs"
-
-[features]
-# Enable this to log warnings when non-blocking GenServers block the runtime for too much time
-warn-on-block = ["dep:pin-project-lite"]

--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -41,7 +41,7 @@ impl<G: GenServer> GenServerHandle<G> {
             }
         };
 
-        #[cfg(feature = "warn-on-block")]
+        #[cfg(debug_assertions)]
         // Optionally warn if the GenServer future blocks for too much time
         let inner_future = warn_on_block::WarnOnBlocking::new(inner_future);
 
@@ -300,7 +300,7 @@ pub trait GenServer: Send + Sized {
     }
 }
 
-#[cfg(feature = "warn-on-block")]
+#[cfg(debug_assertions)]
 mod warn_on_block {
     use super::*;
 


### PR DESCRIPTION
Rationale:
1. `pin-project` only produces a few generics and introduces a few
   macros, meaning virtually no compile time or binary size overhead, so
   having it build inconditionally is not a problem;
2. Using a conditional feature means we need to propagate to the topmost
   manifest to actually use it;
3. It is reasonable enough to run this whenever we want extra checks,
   that is when we use `debug-assertions`.

So, remove the feature, force the dependency and enable the check for
debug-asserted builds.
