### PR TITLE
feat: remove unnecessary trait bounds in genserver messages (`Clone`, `Sync`, `Sized`)

### DIFF
--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -135,9 +135,9 @@ pub enum InitResult<G: GenServer> {
 }
 
 pub trait GenServer: Send + Sized {
-    type CallMsg: Send + Sized;
-    type CastMsg: Send + Sized;
-    type OutMsg: Send + Sized;
+    type CallMsg: Send;
+    type CastMsg: Send;
+    type OutMsg: Send;
     type Error: Debug + Send;
 
     fn start(self) -> GenServerHandle<Self> {

--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -135,8 +135,8 @@ pub enum InitResult<G: GenServer> {
 }
 
 pub trait GenServer: Send + Sized {
-    type CallMsg: Send + Sized + Sync;
-    type CastMsg: Send + Sized + Sync;
+    type CallMsg: Send + Sized;
+    type CastMsg: Send + Sized;
     type OutMsg: Send + Sized;
     type Error: Debug + Send;
 

--- a/concurrency/src/tasks/gen_server.rs
+++ b/concurrency/src/tasks/gen_server.rs
@@ -135,8 +135,8 @@ pub enum InitResult<G: GenServer> {
 }
 
 pub trait GenServer: Send + Sized {
-    type CallMsg: Clone + Send + Sized + Sync;
-    type CastMsg: Clone + Send + Sized + Sync;
+    type CallMsg: Send + Sized + Sync;
+    type CastMsg: Send + Sized + Sync;
     type OutMsg: Send + Sized;
     type Error: Debug + Send;
 

--- a/concurrency/src/tasks/time.rs
+++ b/concurrency/src/tasks/time.rs
@@ -32,7 +32,7 @@ where
 
         let async_block = pin!(async {
             rt::sleep(period).await;
-            let _ = handle.cast(message.clone()).await;
+            let _ = handle.cast(message).await;
         });
         let _ = select(cancel_conditions, async_block).await;
     });
@@ -50,6 +50,7 @@ pub fn send_interval<T>(
 ) -> TimerHandle
 where
     T: GenServer + 'static,
+    T::CastMsg: Clone,
 {
     let cancellation_token = CancellationToken::new();
     let cloned_token = cancellation_token.clone();

--- a/concurrency/src/tasks/time.rs
+++ b/concurrency/src/tasks/time.rs
@@ -62,9 +62,11 @@ where
             let genserver_cancel_fut = pin!(gen_server_cancellation_token.cancelled());
             let cancel_conditions = select(cancel_token_fut, genserver_cancel_fut);
 
-            let async_block = pin!(async {
+            let message_clone = message.clone();
+            let handle_reference = &mut handle;
+            let async_block = pin!(async move {
                 rt::sleep(period).await;
-                let _ = handle.cast(message.clone()).await;
+                let _ = handle_reference.cast(message_clone).await;
             });
             let result = select(cancel_conditions, async_block).await;
             match result {


### PR DESCRIPTION
This PR removes some unneeded bounds in `GenServer` messages, namely `Clone`, `Sync`, and `Sized`.
Of note, `send_interval` still requires `T::CastMsg: Clone`, but this allows users to have non-Cloneable `CastMsg`s when they don't use `send_interval`.