### PR TITLE
fix: make release workflow idempotent for already-published crates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,16 +17,40 @@ jobs:
           override: true
 
       - name: Publish spawned-macros
-        run: cargo publish --package spawned-macros --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          OUTPUT=$(cargo publish --package spawned-macros --token ${{ secrets.CRATES_IO_TOKEN }} 2>&1) || {
+            if echo "$OUTPUT" | grep -q "already exists"; then
+              echo "spawned-macros already published, continuing"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }
 
       - name: Wait for crates.io indexing
         run: sleep 30
 
       - name: Publish spawned-rt
-        run: cargo publish --package spawned-rt --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          OUTPUT=$(cargo publish --package spawned-rt --token ${{ secrets.CRATES_IO_TOKEN }} 2>&1) || {
+            if echo "$OUTPUT" | grep -q "already exists"; then
+              echo "spawned-rt already published, continuing"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }
 
       - name: Wait for crates.io indexing
         run: sleep 30
 
       - name: Publish spawned-concurrency
-        run: cargo publish --package spawned-concurrency --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          OUTPUT=$(cargo publish --package spawned-concurrency --token ${{ secrets.CRATES_IO_TOKEN }} 2>&1) || {
+            if echo "$OUTPUT" | grep -q "already exists"; then
+              echo "spawned-concurrency already published, continuing"
+            else
+              echo "$OUTPUT"
+              exit 1
+            fi
+          }


### PR DESCRIPTION
## Summary
- Skip "already exists" errors during `cargo publish` so re-runs succeed
- Real errors (permission denied, network, etc.) still fail the workflow

Needed because `spawned-macros` 0.5.0 was published manually, so the release workflow fails when trying to publish it again.