### PR TITLE
feat: add ExitReason tracking for actor lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "exit_reason"
+version = "0.1.0"
+dependencies = [
+ "spawned-concurrency",
+ "spawned-rt",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/chat_room",
     "examples/chat_room_threads",
     "examples/service_discovery",
+    "examples/exit_reason",
 ]
 
 [workspace.dependencies]

--- a/concurrency/src/error.rs
+++ b/concurrency/src/error.rs
@@ -1,19 +1,22 @@
 /// Reason an actor stopped. Used by supervision to decide whether to restart.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ExitReason {
     /// Clean stop via `ctx.stop()` or channel closure.
     Normal,
     /// Ordered shutdown from a supervisor or linked actor.
+    /// Not yet produced — reserved for supervision tree implementation.
     Shutdown,
     /// Actor panicked in `started()`, a handler, or `stopped()`.
     Panic(String),
     /// Untrappable kill signal.
+    /// Not yet produced — reserved for supervision tree implementation.
     Kill,
 }
 
 impl ExitReason {
     /// Returns `true` for exit reasons that should trigger a restart
     /// of `Transient` or `Permanent` children.
+    /// `Shutdown` is considered normal (no restart) matching Erlang semantics.
     pub fn is_abnormal(&self) -> bool {
         match self {
             ExitReason::Normal | ExitReason::Shutdown => false,
@@ -30,6 +33,17 @@ impl std::fmt::Display for ExitReason {
             ExitReason::Panic(msg) => write!(f, "panic: {msg}"),
             ExitReason::Kill => write!(f, "kill"),
         }
+    }
+}
+
+/// Extract a human-readable message from a panic payload.
+pub(crate) fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{panic:?}")
     }
 }
 
@@ -69,5 +83,31 @@ mod tests {
     fn test_error_into_std_error() {
         let error: &dyn std::error::Error = &ActorError::ActorStopped;
         assert_eq!(error.to_string(), "Actor stopped");
+    }
+
+    #[test]
+    fn exit_reason_is_abnormal_classification() {
+        assert!(!ExitReason::Normal.is_abnormal());
+        assert!(!ExitReason::Shutdown.is_abnormal());
+        assert!(ExitReason::Panic("boom".into()).is_abnormal());
+        assert!(ExitReason::Kill.is_abnormal());
+    }
+
+    #[test]
+    fn exit_reason_display() {
+        assert_eq!(ExitReason::Normal.to_string(), "normal");
+        assert_eq!(ExitReason::Shutdown.to_string(), "shutdown");
+        assert_eq!(ExitReason::Panic("oops".into()).to_string(), "panic: oops");
+        assert_eq!(ExitReason::Kill.to_string(), "kill");
+    }
+
+    #[test]
+    fn exit_reason_partial_eq() {
+        assert_eq!(ExitReason::Normal, ExitReason::Normal);
+        assert_ne!(ExitReason::Normal, ExitReason::Kill);
+        assert_eq!(
+            ExitReason::Panic("x".into()),
+            ExitReason::Panic("x".into())
+        );
     }
 }

--- a/concurrency/src/error.rs
+++ b/concurrency/src/error.rs
@@ -1,3 +1,38 @@
+/// Reason an actor stopped. Used by supervision to decide whether to restart.
+#[derive(Debug, Clone)]
+pub enum ExitReason {
+    /// Clean stop via `ctx.stop()` or channel closure.
+    Normal,
+    /// Ordered shutdown from a supervisor or linked actor.
+    Shutdown,
+    /// Actor panicked in `started()`, a handler, or `stopped()`.
+    Panic(String),
+    /// Untrappable kill signal.
+    Kill,
+}
+
+impl ExitReason {
+    /// Returns `true` for exit reasons that should trigger a restart
+    /// of `Transient` or `Permanent` children.
+    pub fn is_abnormal(&self) -> bool {
+        match self {
+            ExitReason::Normal | ExitReason::Shutdown => false,
+            ExitReason::Panic(_) | ExitReason::Kill => true,
+        }
+    }
+}
+
+impl std::fmt::Display for ExitReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExitReason::Normal => write!(f, "normal"),
+            ExitReason::Shutdown => write!(f, "shutdown"),
+            ExitReason::Panic(msg) => write!(f, "panic: {msg}"),
+            ExitReason::Kill => write!(f, "kill"),
+        }
+    }
+}
+
 /// Errors that can occur when communicating with an actor.
 #[derive(Debug, thiserror::Error)]
 pub enum ActorError {

--- a/concurrency/src/error.rs
+++ b/concurrency/src/error.rs
@@ -105,9 +105,6 @@ mod tests {
     fn exit_reason_partial_eq() {
         assert_eq!(ExitReason::Normal, ExitReason::Normal);
         assert_ne!(ExitReason::Normal, ExitReason::Kill);
-        assert_eq!(
-            ExitReason::Panic("x".into()),
-            ExitReason::Panic("x".into())
-        );
+        assert_eq!(ExitReason::Panic("x".into()), ExitReason::Panic("x".into()));
     }
 }

--- a/concurrency/src/error.rs
+++ b/concurrency/src/error.rs
@@ -8,8 +8,9 @@ pub enum ExitReason {
     Shutdown,
     /// Actor panicked in `started()`, a handler, or `stopped()`.
     Panic(String),
-    /// Untrappable kill signal.
-    /// Not yet produced — reserved for supervision tree implementation.
+    /// Untrappable kill signal. Bypasses `trap_exit` and skips `stopped()` cleanup.
+    /// Currently produced as a fallback when an async task is aborted externally.
+    /// Will also be used by supervision for `ShutdownType::BrutalKill`.
     Kill,
 }
 

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -78,6 +78,6 @@ pub mod response;
 pub mod tasks;
 pub mod threads;
 
-pub use error::ActorError;
+pub use error::{ActorError, ExitReason};
 pub use response::Response;
 pub use spawned_macros::{actor, protocol};

--- a/concurrency/src/tasks/actor.rs
+++ b/concurrency/src/tasks/actor.rs
@@ -1,4 +1,4 @@
-use crate::error::ActorError;
+use crate::error::{ActorError, ExitReason};
 use crate::message::Message;
 use core::pin::pin;
 use futures::future::{self, FutureExt as _};
@@ -108,7 +108,7 @@ where
 pub struct Context<A: Actor> {
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-    completion_rx: watch::Receiver<bool>,
+    completion_rx: watch::Receiver<Option<ExitReason>>,
 }
 
 impl<A: Actor> Clone for Context<A> {
@@ -281,7 +281,7 @@ pub async fn request<M: Message>(
 pub struct ActorRef<A: Actor> {
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-    completion_rx: watch::Receiver<bool>,
+    completion_rx: watch::Receiver<Option<ExitReason>>,
 }
 
 impl<A: Actor> Debug for ActorRef<A> {
@@ -371,10 +371,23 @@ impl<A: Actor> ActorRef<A> {
 
     /// Wait until the actor has fully stopped (including `stopped()` callback).
     pub async fn join(&self) {
+        let _ = self.wait_exit().await;
+    }
+
+    /// Poll the exit reason. Returns `None` if the actor is still running.
+    pub fn exit_reason(&self) -> Option<ExitReason> {
+        self.completion_rx.borrow().clone()
+    }
+
+    /// Wait until the actor stops and return the exit reason.
+    pub async fn wait_exit(&self) -> ExitReason {
         let mut rx = self.completion_rx.clone();
-        while !*rx.borrow_and_update() {
+        loop {
+            if let Some(reason) = rx.borrow_and_update().clone() {
+                return reason;
+            }
             if rx.changed().await.is_err() {
-                break;
+                return ExitReason::Normal;
             }
         }
     }
@@ -403,7 +416,7 @@ impl<A: Actor> ActorRef<A> {
     fn spawn(actor: A, backend: Backend) -> Self {
         let (tx, rx) = mpsc::channel::<Box<dyn Envelope<A> + Send>>();
         let cancellation_token = CancellationToken::new();
-        let (completion_tx, completion_rx) = watch::channel(false);
+        let (completion_tx, completion_rx) = watch::channel(None);
 
         let actor_ref = ActorRef {
             sender: tx.clone(),
@@ -418,8 +431,8 @@ impl<A: Actor> ActorRef<A> {
         };
 
         let inner_future = async move {
-            run_actor(actor, ctx, rx, cancellation_token).await;
-            let _ = completion_tx.send(true);
+            let reason = run_actor(actor, ctx, rx, cancellation_token).await;
+            let _ = completion_tx.send(Some(reason));
         };
 
         match backend {
@@ -445,18 +458,21 @@ async fn run_actor<A: Actor>(
     ctx: Context<A>,
     mut rx: mpsc::Receiver<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-) {
+) -> ExitReason {
     let start_result = AssertUnwindSafe(actor.started(&ctx)).catch_unwind().await;
     if let Err(panic) = start_result {
-        tracing::error!("Panic in started() callback: {panic:?}");
+        let msg = panic_message(&panic);
+        tracing::error!("Panic in started() callback: {msg}");
         cancellation_token.cancel();
-        return;
+        return ExitReason::Panic(format!("panic in started(): {msg}"));
     }
 
     if cancellation_token.is_cancelled() {
         let _ = AssertUnwindSafe(actor.stopped(&ctx)).catch_unwind().await;
-        return;
+        return ExitReason::Normal;
     }
+
+    let mut exit_reason = ExitReason::Normal;
 
     loop {
         let msg = {
@@ -473,7 +489,9 @@ async fn run_actor<A: Actor>(
                     .catch_unwind()
                     .await;
                 if let Err(panic) = result {
-                    tracing::error!("Panic in message handler: {panic:?}");
+                    let msg = panic_message(&panic);
+                    tracing::error!("Panic in message handler: {msg}");
+                    exit_reason = ExitReason::Panic(format!("panic in handler: {msg}"));
                     break;
                 }
                 if cancellation_token.is_cancelled() {
@@ -487,7 +505,20 @@ async fn run_actor<A: Actor>(
     cancellation_token.cancel();
     let stop_result = AssertUnwindSafe(actor.stopped(&ctx)).catch_unwind().await;
     if let Err(panic) = stop_result {
-        tracing::error!("Panic in stopped() callback: {panic:?}");
+        let msg = panic_message(&panic);
+        tracing::error!("Panic in stopped() callback: {msg}");
+    }
+
+    exit_reason
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{panic:?}")
     }
 }
 
@@ -1102,6 +1133,78 @@ mod tests {
             let final_count = counter.request(StopCounter).await.unwrap();
             assert_eq!(final_count, 0, "message should not have been delivered");
             counter.join().await;
+        });
+    }
+
+    // --- ExitReason tests ---
+
+    #[test]
+    pub fn exit_reason_normal_on_clean_stop() {
+        let runtime = rt::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let actor = Counter { count: 0 }.start();
+            actor.request(StopCounter).await.unwrap();
+            let reason = actor.wait_exit().await;
+            assert!(matches!(reason, ExitReason::Normal));
+        });
+    }
+
+    #[test]
+    pub fn exit_reason_panic_in_started() {
+        struct PanicStart;
+        struct Ping;
+        impl Message for Ping {
+            type Result = ();
+        }
+        impl Actor for PanicStart {
+            async fn started(&mut self, _ctx: &Context<Self>) {
+                panic!("boom in started");
+            }
+        }
+        impl Handler<Ping> for PanicStart {
+            async fn handle(&mut self, _msg: Ping, _ctx: &Context<Self>) {}
+        }
+
+        let runtime = rt::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let actor = PanicStart.start();
+            let reason = actor.wait_exit().await;
+            assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in started")));
+        });
+    }
+
+    #[test]
+    pub fn exit_reason_panic_in_handler() {
+        struct PanicHandler;
+        struct Explode;
+        impl Message for Explode {
+            type Result = ();
+        }
+        impl Actor for PanicHandler {}
+        impl Handler<Explode> for PanicHandler {
+            async fn handle(&mut self, _msg: Explode, _ctx: &Context<Self>) {
+                panic!("boom in handler");
+            }
+        }
+
+        let runtime = rt::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let actor = PanicHandler.start();
+            let _ = actor.send(Explode);
+            let reason = actor.wait_exit().await;
+            assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in handler")));
+        });
+    }
+
+    #[test]
+    pub fn exit_reason_poll_returns_none_while_running() {
+        let runtime = rt::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            let actor = Counter { count: 0 }.start();
+            assert!(actor.exit_reason().is_none());
+            actor.request(StopCounter).await.unwrap();
+            actor.join().await;
+            assert!(actor.exit_reason().is_some());
         });
     }
 }

--- a/concurrency/src/tasks/actor.rs
+++ b/concurrency/src/tasks/actor.rs
@@ -1,4 +1,4 @@
-use crate::error::{ActorError, ExitReason};
+use crate::error::{panic_message, ActorError, ExitReason};
 use crate::message::Message;
 use core::pin::pin;
 use futures::future::{self, FutureExt as _};
@@ -387,7 +387,7 @@ impl<A: Actor> ActorRef<A> {
                 return reason;
             }
             if rx.changed().await.is_err() {
-                return ExitReason::Normal;
+                return ExitReason::Kill;
             }
         }
     }
@@ -461,7 +461,7 @@ async fn run_actor<A: Actor>(
 ) -> ExitReason {
     let start_result = AssertUnwindSafe(actor.started(&ctx)).catch_unwind().await;
     if let Err(panic) = start_result {
-        let msg = panic_message(&panic);
+        let msg = panic_message(&*panic);
         tracing::error!("Panic in started() callback: {msg}");
         cancellation_token.cancel();
         return ExitReason::Panic(format!("panic in started(): {msg}"));
@@ -489,7 +489,7 @@ async fn run_actor<A: Actor>(
                     .catch_unwind()
                     .await;
                 if let Err(panic) = result {
-                    let msg = panic_message(&panic);
+                    let msg = panic_message(&*panic);
                     tracing::error!("Panic in message handler: {msg}");
                     exit_reason = ExitReason::Panic(format!("panic in handler: {msg}"));
                     break;
@@ -505,21 +505,14 @@ async fn run_actor<A: Actor>(
     cancellation_token.cancel();
     let stop_result = AssertUnwindSafe(actor.stopped(&ctx)).catch_unwind().await;
     if let Err(panic) = stop_result {
-        let msg = panic_message(&panic);
+        let msg = panic_message(&*panic);
         tracing::error!("Panic in stopped() callback: {msg}");
+        if !exit_reason.is_abnormal() {
+            exit_reason = ExitReason::Panic(format!("panic in stopped(): {msg}"));
+        }
     }
 
     exit_reason
-}
-
-fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = panic.downcast_ref::<&str>() {
-        s.to_string()
-    } else if let Some(s) = panic.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        format!("{panic:?}")
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/concurrency/src/tasks/actor.rs
+++ b/concurrency/src/tasks/actor.rs
@@ -1162,7 +1162,9 @@ mod tests {
         runtime.block_on(async move {
             let actor = PanicStart.start();
             let reason = actor.wait_exit().await;
-            assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in started")));
+            assert!(
+                matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in started"))
+            );
         });
     }
 
@@ -1185,7 +1187,9 @@ mod tests {
             let actor = PanicHandler.start();
             let _ = actor.send(Explode);
             let reason = actor.wait_exit().await;
-            assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in handler")));
+            assert!(
+                matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in handler"))
+            );
         });
     }
 

--- a/concurrency/src/threads/actor.rs
+++ b/concurrency/src/threads/actor.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use crate::error::{ActorError, ExitReason};
+use crate::error::{panic_message, ActorError, ExitReason};
 use crate::message::Message;
 
 pub use crate::response::DEFAULT_REQUEST_TIMEOUT;
@@ -240,14 +240,14 @@ pub fn request<M: Message>(
 
 struct CompletionGuard {
     completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
-    reason: ExitReason,
+    reason: Option<ExitReason>,
 }
 
 impl Drop for CompletionGuard {
     fn drop(&mut self) {
         let (lock, cvar) = &*self.completion;
         let mut completed = lock.lock().unwrap_or_else(|p| p.into_inner());
-        *completed = Some(std::mem::replace(&mut self.reason, ExitReason::Normal));
+        *completed = self.reason.take().or(Some(ExitReason::Kill));
         cvar.notify_all();
     }
 }
@@ -410,12 +410,11 @@ impl<A: Actor> ActorRef<A> {
         };
 
         let _thread_handle = rt::spawn(move || {
-            let reason = run_actor(actor, ctx, rx, cancellation_token);
-            let guard = CompletionGuard {
+            let mut guard = CompletionGuard {
                 completion,
-                reason,
+                reason: None, // defaults to Kill if run_actor panics unexpectedly
             };
-            drop(guard);
+            guard.reason = Some(run_actor(actor, ctx, rx, cancellation_token));
         });
 
         actor_ref
@@ -432,7 +431,7 @@ fn run_actor<A: Actor>(
         actor.started(&ctx);
     }));
     if let Err(panic) = start_result {
-        let msg = panic_message(&panic);
+        let msg = panic_message(&*panic);
         tracing::error!("Panic in started() callback: {msg}");
         cancellation_token.cancel();
         return ExitReason::Panic(format!("panic in started(): {msg}"));
@@ -462,7 +461,7 @@ fn run_actor<A: Actor>(
                     envelope.handle(&mut actor, &ctx);
                 }));
                 if let Err(panic) = result {
-                    let msg = panic_message(&panic);
+                    let msg = panic_message(&*panic);
                     tracing::error!("Panic in message handler: {msg}");
                     exit_reason = ExitReason::Panic(format!("panic in handler: {msg}"));
                     break;
@@ -480,21 +479,14 @@ fn run_actor<A: Actor>(
         actor.stopped(&ctx);
     }));
     if let Err(panic) = stop_result {
-        let msg = panic_message(&panic);
+        let msg = panic_message(&*panic);
         tracing::error!("Panic in stopped() callback: {msg}");
+        if !exit_reason.is_abnormal() {
+            exit_reason = ExitReason::Panic(format!("panic in stopped(): {msg}"));
+        }
     }
 
     exit_reason
-}
-
-fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(s) = panic.downcast_ref::<&str>() {
-        s.to_string()
-    } else if let Some(s) = panic.downcast_ref::<String>() {
-        s.clone()
-    } else {
-        format!("{panic:?}")
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/concurrency/src/threads/actor.rs
+++ b/concurrency/src/threads/actor.rs
@@ -247,7 +247,10 @@ impl Drop for CompletionGuard {
     fn drop(&mut self) {
         let (lock, cvar) = &*self.completion;
         let mut completed = lock.lock().unwrap_or_else(|p| p.into_inner());
-        *completed = self.reason.take().or(Some(ExitReason::Kill));
+        *completed = self
+            .reason
+            .take()
+            .or(Some(ExitReason::Panic("unexpected framework panic".into())));
         cvar.notify_all();
     }
 }

--- a/concurrency/src/threads/actor.rs
+++ b/concurrency/src/threads/actor.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use crate::error::ActorError;
+use crate::error::{ActorError, ExitReason};
 use crate::message::Message;
 
 pub use crate::response::DEFAULT_REQUEST_TIMEOUT;
@@ -76,7 +76,7 @@ where
 pub struct Context<A: Actor> {
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-    completion: Arc<(Mutex<bool>, Condvar)>,
+    completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
 }
 
 impl<A: Actor> Clone for Context<A> {
@@ -238,13 +238,16 @@ pub fn request<M: Message>(
 // ActorRef
 // ---------------------------------------------------------------------------
 
-struct CompletionGuard(Arc<(Mutex<bool>, Condvar)>);
+struct CompletionGuard {
+    completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
+    reason: ExitReason,
+}
 
 impl Drop for CompletionGuard {
     fn drop(&mut self) {
-        let (lock, cvar) = &*self.0;
+        let (lock, cvar) = &*self.completion;
         let mut completed = lock.lock().unwrap_or_else(|p| p.into_inner());
-        *completed = true;
+        *completed = Some(std::mem::replace(&mut self.reason, ExitReason::Normal));
         cvar.notify_all();
     }
 }
@@ -257,7 +260,7 @@ impl Drop for CompletionGuard {
 pub struct ActorRef<A: Actor> {
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-    completion: Arc<(Mutex<bool>, Condvar)>,
+    completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
 }
 
 impl<A: Actor> Debug for ActorRef<A> {
@@ -346,9 +349,24 @@ impl<A: Actor> ActorRef<A> {
 
     /// Block until the actor has fully stopped (including `stopped()` callback).
     pub fn join(&self) {
+        let _ = self.wait_exit();
+    }
+
+    /// Poll the exit reason. Returns `None` if the actor is still running.
+    pub fn exit_reason(&self) -> Option<ExitReason> {
+        let (lock, _cvar) = &*self.completion;
+        let completed = lock.lock().unwrap_or_else(|p| p.into_inner());
+        completed.clone()
+    }
+
+    /// Block until the actor stops and return the exit reason.
+    pub fn wait_exit(&self) -> ExitReason {
         let (lock, cvar) = &*self.completion;
         let mut completed = lock.lock().unwrap_or_else(|p| p.into_inner());
-        while !*completed {
+        loop {
+            if let Some(reason) = completed.clone() {
+                return reason;
+            }
             completed = cvar.wait(completed).unwrap_or_else(|p| p.into_inner());
         }
     }
@@ -377,7 +395,7 @@ impl<A: Actor> ActorRef<A> {
     fn spawn(actor: A) -> Self {
         let (tx, rx) = mpsc::channel::<Box<dyn Envelope<A> + Send>>();
         let cancellation_token = CancellationToken::new();
-        let completion = Arc::new((Mutex::new(false), Condvar::new()));
+        let completion = Arc::new((Mutex::new(None), Condvar::new()));
 
         let actor_ref = ActorRef {
             sender: tx.clone(),
@@ -392,8 +410,12 @@ impl<A: Actor> ActorRef<A> {
         };
 
         let _thread_handle = rt::spawn(move || {
-            let _guard = CompletionGuard(completion);
-            run_actor(actor, ctx, rx, cancellation_token);
+            let reason = run_actor(actor, ctx, rx, cancellation_token);
+            let guard = CompletionGuard {
+                completion,
+                reason,
+            };
+            drop(guard);
         });
 
         actor_ref
@@ -405,20 +427,23 @@ fn run_actor<A: Actor>(
     ctx: Context<A>,
     rx: mpsc::Receiver<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
-) {
+) -> ExitReason {
     let start_result = catch_unwind(AssertUnwindSafe(|| {
         actor.started(&ctx);
     }));
     if let Err(panic) = start_result {
-        tracing::error!("Panic in started() callback: {panic:?}");
+        let msg = panic_message(&panic);
+        tracing::error!("Panic in started() callback: {msg}");
         cancellation_token.cancel();
-        return;
+        return ExitReason::Panic(format!("panic in started(): {msg}"));
     }
 
     if cancellation_token.is_cancelled() {
         let _ = catch_unwind(AssertUnwindSafe(|| actor.stopped(&ctx)));
-        return;
+        return ExitReason::Normal;
     }
+
+    let mut exit_reason = ExitReason::Normal;
 
     loop {
         let msg = match rx.recv_timeout(Duration::from_millis(100)) {
@@ -437,7 +462,9 @@ fn run_actor<A: Actor>(
                     envelope.handle(&mut actor, &ctx);
                 }));
                 if let Err(panic) = result {
-                    tracing::error!("Panic in message handler: {panic:?}");
+                    let msg = panic_message(&panic);
+                    tracing::error!("Panic in message handler: {msg}");
+                    exit_reason = ExitReason::Panic(format!("panic in handler: {msg}"));
                     break;
                 }
                 if cancellation_token.is_cancelled() {
@@ -453,7 +480,20 @@ fn run_actor<A: Actor>(
         actor.stopped(&ctx);
     }));
     if let Err(panic) = stop_result {
-        tracing::error!("Panic in stopped() callback: {panic:?}");
+        let msg = panic_message(&panic);
+        tracing::error!("Panic in stopped() callback: {msg}");
+    }
+
+    exit_reason
+}
+
+fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        format!("{panic:?}")
     }
 }
 
@@ -703,5 +743,65 @@ mod tests {
         rt::sleep(Duration::from_millis(200));
         let count = actor.request(GetCount).unwrap();
         assert_eq!(count, 1);
+    }
+
+    // --- ExitReason tests ---
+
+    #[test]
+    fn exit_reason_normal_on_clean_stop() {
+        let actor = Counter { count: 0 }.start();
+        actor.request(StopCounter).unwrap();
+        let reason = actor.wait_exit();
+        assert!(matches!(reason, ExitReason::Normal));
+    }
+
+    #[test]
+    fn exit_reason_panic_in_started() {
+        struct PanicStartThread;
+        struct PingThread2;
+        impl Message for PingThread2 {
+            type Result = ();
+        }
+        impl Actor for PanicStartThread {
+            fn started(&mut self, _ctx: &Context<Self>) {
+                panic!("boom in started");
+            }
+        }
+        impl Handler<PingThread2> for PanicStartThread {
+            fn handle(&mut self, _msg: PingThread2, _ctx: &Context<Self>) {}
+        }
+
+        let actor = PanicStartThread.start();
+        let reason = actor.wait_exit();
+        assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in started")));
+    }
+
+    #[test]
+    fn exit_reason_panic_in_handler() {
+        struct PanicHandlerThread;
+        struct ExplodeThread2;
+        impl Message for ExplodeThread2 {
+            type Result = ();
+        }
+        impl Actor for PanicHandlerThread {}
+        impl Handler<ExplodeThread2> for PanicHandlerThread {
+            fn handle(&mut self, _msg: ExplodeThread2, _ctx: &Context<Self>) {
+                panic!("boom in handler");
+            }
+        }
+
+        let actor = PanicHandlerThread.start();
+        let _ = actor.send(ExplodeThread2);
+        let reason = actor.wait_exit();
+        assert!(matches!(reason, ExitReason::Panic(ref msg) if msg.contains("boom in handler")));
+    }
+
+    #[test]
+    fn exit_reason_poll_returns_none_while_running() {
+        let actor = Counter { count: 0 }.start();
+        assert!(actor.exit_reason().is_none());
+        actor.request(StopCounter).unwrap();
+        actor.join();
+        assert!(actor.exit_reason().is_some());
     }
 }

--- a/examples/exit_reason/Cargo.toml
+++ b/examples/exit_reason/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "exit_reason"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "exit_reason"
+path = "src/main.rs"
+
+[dependencies]
+spawned-concurrency = { workspace = true }
+spawned-rt = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/examples/exit_reason/src/main.rs
+++ b/examples/exit_reason/src/main.rs
@@ -1,6 +1,6 @@
+use spawned_concurrency::protocol;
 use spawned_concurrency::tasks::{Actor, ActorStart, Context, Handler};
 use spawned_concurrency::Response;
-use spawned_concurrency::protocol;
 use spawned_rt::tasks as rt;
 use std::time::Duration;
 
@@ -48,11 +48,7 @@ impl Worker {
     }
 
     #[request_handler]
-    async fn handle_ping(
-        &mut self,
-        _msg: worker_protocol::Ping,
-        _ctx: &Context<Self>,
-    ) -> String {
+    async fn handle_ping(&mut self, _msg: worker_protocol::Ping, _ctx: &Context<Self>) -> String {
         format!("pong from {}", self.name)
     }
 }

--- a/examples/exit_reason/src/main.rs
+++ b/examples/exit_reason/src/main.rs
@@ -1,0 +1,119 @@
+use spawned_concurrency::tasks::{Actor, ActorStart, Context, Handler};
+use spawned_concurrency::Response;
+use spawned_concurrency::protocol;
+use spawned_rt::tasks as rt;
+use std::time::Duration;
+
+// -- A simple worker that can be told to stop, panic, or just keep running --
+
+struct Worker {
+    name: String,
+}
+
+#[protocol]
+trait WorkerProtocol: Send + Sync {
+    fn stop(&self) -> Response<()>;
+    fn panic_now(&self) -> Response<()>;
+    fn ping(&self) -> Response<String>;
+}
+
+#[spawned_concurrency::actor(protocol = WorkerProtocol)]
+impl Worker {
+    fn new(name: &str) -> Self {
+        Worker {
+            name: name.to_string(),
+        }
+    }
+
+    #[started]
+    async fn started(&mut self, _ctx: &Context<Self>) {
+        tracing::info!("[{}] started", self.name);
+    }
+
+    #[stopped]
+    async fn stopped(&mut self, _ctx: &Context<Self>) {
+        tracing::info!("[{}] stopped callback running", self.name);
+    }
+
+    #[request_handler]
+    async fn handle_stop(&mut self, _msg: worker_protocol::Stop, ctx: &Context<Self>) {
+        tracing::info!("[{}] received stop request", self.name);
+        ctx.stop();
+    }
+
+    #[request_handler]
+    async fn handle_panic_now(&mut self, _msg: worker_protocol::PanicNow, _ctx: &Context<Self>) {
+        tracing::info!("[{}] about to panic!", self.name);
+        panic!("intentional panic from {}", self.name);
+    }
+
+    #[request_handler]
+    async fn handle_ping(
+        &mut self,
+        _msg: worker_protocol::Ping,
+        _ctx: &Context<Self>,
+    ) -> String {
+        format!("pong from {}", self.name)
+    }
+}
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_target(false)
+        .with_level(true)
+        .init();
+
+    rt::run(async {
+        println!("=== Exit Reason Demo ===\n");
+
+        // 1. Clean stop via ctx.stop()
+        println!("--- Scenario 1: Clean stop ---");
+        let worker1 = Worker::new("worker-1").start();
+        let pong = worker1.ping().await.unwrap();
+        println!("  {pong}");
+        worker1.stop().await.unwrap();
+        let reason = worker1.wait_exit().await;
+        println!("  Exit reason: {reason}");
+        println!("  is_abnormal: {}\n", reason.is_abnormal());
+
+        // 2. Panic in handler
+        println!("--- Scenario 2: Panic in handler ---");
+        let worker2 = Worker::new("worker-2").start();
+        let _ = worker2.panic_now().await; // will fail, actor panics
+        let reason = worker2.wait_exit().await;
+        println!("  Exit reason: {reason}");
+        println!("  is_abnormal: {}\n", reason.is_abnormal());
+
+        // 3. Panic in started()
+        println!("--- Scenario 3: Panic in started() ---");
+        struct PanicOnStart;
+        struct Noop;
+        impl spawned_concurrency::message::Message for Noop {
+            type Result = ();
+        }
+        impl Actor for PanicOnStart {
+            async fn started(&mut self, _ctx: &Context<Self>) {
+                panic!("can't start!");
+            }
+        }
+        impl Handler<Noop> for PanicOnStart {
+            async fn handle(&mut self, _msg: Noop, _ctx: &Context<Self>) {}
+        }
+        let worker3 = PanicOnStart.start();
+        let reason = worker3.wait_exit().await;
+        println!("  Exit reason: {reason}");
+        println!("  is_abnormal: {}\n", reason.is_abnormal());
+
+        // 4. Polling exit_reason() while running
+        println!("--- Scenario 4: Polling exit_reason() ---");
+        let worker4 = Worker::new("worker-4").start();
+        println!("  While running: {:?}", worker4.exit_reason());
+        worker4.stop().await.unwrap();
+        worker4.join().await;
+        println!("  After stop:   {:?}", worker4.exit_reason());
+
+        // Give tracing a moment to flush
+        rt::sleep(Duration::from_millis(50)).await;
+        println!("\n=== Done ===");
+    });
+}


### PR DESCRIPTION
## Summary
- Adds `ExitReason` enum (`Normal`, `Shutdown`, `Panic(String)`, `Kill`) with `is_abnormal()` method
- Actors now report WHY they stopped, not just that they did
- `ActorRef::wait_exit()` returns the exit reason (async in tasks, blocking in threads)
- `ActorRef::exit_reason()` polls the reason without blocking
- `join()` unchanged for backwards compatibility
- Includes `exit_reason` example demonstrating all exit paths

Foundation for supervision trees (#131, #133). The watch channel changes from `bool` to `Option<ExitReason>` in tasks mode, and `Mutex<bool>` to `Mutex<Option<ExitReason>>` in threads mode. `run_actor()` now returns `ExitReason` on every exit path: clean stop, channel closure, panic in started(), and panic in handler.

## Test plan
- [x] 8 new tests (4 per execution mode): clean stop, panic in started, panic in handler, polling
- [x] All 67 existing tests pass (no regressions from watch channel type change)
- [x] Runnable example: `cargo run -p exit_reason`