### PR TITLE
feat: add ChildHandle and ActorId for type-erased actor management

### DIFF
--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -125,9 +125,17 @@ impl ChildHandle {
 
     /// Block the calling thread until the actor stops and return the exit reason.
     ///
-    /// Safe to call from any context (sync or async). For the Watch variant,
-    /// uses the watch channel's built-in blocking recv. For Condvar, blocks
-    /// on the condvar directly.
+    /// Safe contexts:
+    /// - Sync code with no active tokio runtime
+    /// - Multi-thread tokio runtime (uses `block_in_place`)
+    /// - Threads-mode actors (uses Condvar directly)
+    ///
+    /// **Panics** if called from within a current-thread tokio runtime on a
+    /// tasks-mode handle: blocking the only runtime thread would prevent the
+    /// actor task from making progress (deadlock). Use [`wait_exit_async`] from
+    /// async context instead.
+    ///
+    /// [`wait_exit_async`]: ChildHandle::wait_exit_async
     pub fn wait_exit_blocking(&self) -> ExitReason {
         match &self.completion {
             Completion::Watch(rx) => {
@@ -179,8 +187,13 @@ impl ChildHandle {
     }
 }
 
-/// Blocking wait on a watch channel. Uses `block_in_place` if inside a tokio
-/// runtime (safe from multi-threaded runtime), otherwise creates a temporary runtime.
+/// Blocking wait on a watch channel.
+///
+/// - From a sync context (no tokio runtime): creates a temporary runtime.
+/// - From a multi-thread tokio runtime: uses `block_in_place` + `Handle::block_on`.
+/// - From a current-thread tokio runtime: **panics**, because blocking the only
+///   runtime thread prevents the actor task from making progress (deadlock).
+///   Use `wait_exit_async` from async context, or run on a multi-thread runtime.
 ///
 /// Returns `ExitReason::Kill` if the watch sender is dropped without setting a
 /// reason — this means the actor task was aborted externally (e.g., runtime
@@ -188,7 +201,7 @@ impl ChildHandle {
 fn wait_for_exit_watch_blocking(
     rx: &spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
 ) -> ExitReason {
-    // Fast path: already done
+    // Fast path: already done — works from any context, no runtime needed
     if let Some(reason) = rx.borrow().clone() {
         return reason;
     }
@@ -205,12 +218,24 @@ fn wait_for_exit_watch_blocking(
         }
     };
 
-    // If inside a tokio runtime, use block_in_place + block_on to avoid
-    // "cannot start a runtime from within a runtime" panic.
-    if let Ok(handle) = spawned_rt::tasks::Handle::try_current() {
-        spawned_rt::tasks::block_in_place(|| handle.block_on(wait))
-    } else {
-        spawned_rt::threads::block_on(wait)
+    match spawned_rt::tasks::Handle::try_current() {
+        // No active runtime — create a temporary one
+        Err(_) => spawned_rt::threads::block_on(wait),
+        // Inside a tokio runtime — check the flavor
+        Ok(handle) => match handle.runtime_flavor() {
+            spawned_rt::tasks::RuntimeFlavor::MultiThread => {
+                spawned_rt::tasks::block_in_place(|| handle.block_on(wait))
+            }
+            // CurrentThread runtime: blocking here would deadlock the actor task.
+            // Including future flavors (e.g., MultiThreadAlt) for safety — only
+            // MultiThread is known to be safe with block_in_place.
+            _ => panic!(
+                "ChildHandle::wait_exit_blocking() cannot be called from within a \
+                current_thread tokio runtime; doing so would deadlock the actor \
+                task that this call is waiting for. Use wait_exit_async() from \
+                async context instead, or run on a multi-thread runtime."
+            ),
+        },
     }
 }
 
@@ -372,21 +397,68 @@ mod tests {
     }
 
     #[test]
-    fn child_handle_wait_blocking_inside_runtime() {
+    fn child_handle_wait_blocking_inside_multithread_runtime() {
         use crate::tasks::actor::{Actor, ActorStart};
 
         struct Idler;
         impl Actor for Idler {}
 
+        // Multi-thread runtime — wait_exit_blocking should work via block_in_place
         let runtime = spawned_rt::tasks::Runtime::new().unwrap();
         runtime.block_on(async {
             let actor = Idler.start();
             let handle = actor.child_handle();
             handle.stop();
 
-            // This is the bug-fix test: wait_exit_blocking inside a tokio runtime
-            // should NOT panic (uses block_in_place internally)
-            let reason = spawned_rt::tasks::block_in_place(|| handle.wait_exit_blocking());
+            let reason = handle.wait_exit_blocking();
+            assert_eq!(reason, ExitReason::Normal);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "current_thread tokio runtime")]
+    fn child_handle_wait_blocking_panics_on_current_thread_runtime() {
+        use crate::tasks::actor::{Actor, ActorStart};
+
+        struct Idler;
+        impl Actor for Idler {}
+
+        let runtime = ::tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let actor = Idler.start();
+            let handle = actor.child_handle();
+            // Calling wait_exit_blocking from within a current-thread runtime
+            // would deadlock the actor task — we panic with a clear message instead.
+            let _ = handle.wait_exit_blocking();
+        });
+    }
+
+    #[test]
+    fn child_handle_wait_blocking_fast_path_on_current_thread_runtime() {
+        use crate::tasks::actor::{Actor, ActorStart};
+
+        struct Idler;
+        impl Actor for Idler {}
+
+        let runtime = ::tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        // Fast path: if the actor has already exited, wait_exit_blocking is safe
+        // even on a current-thread runtime (no actual blocking happens).
+        runtime.block_on(async {
+            let actor = Idler.start();
+            let handle = actor.child_handle();
+            handle.stop();
+            // Wait async first so the actor actually exits
+            let _ = handle.wait_exit_async().await;
+            // Now wait_exit_blocking takes the fast path
+            let reason = handle.wait_exit_blocking();
             assert_eq!(reason, ExitReason::Normal);
         });
     }

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -34,9 +34,9 @@ impl std::fmt::Display for ActorId {
 #[derive(Clone)]
 pub(crate) enum Completion {
     /// Tasks mode: watch channel carrying Option<ExitReason>.
-    Watch(spawned_rt::tasks::watch::Receiver<Option<ExitReason>>),
+    Tasks(spawned_rt::tasks::watch::Receiver<Option<ExitReason>>),
     /// Threads mode: Mutex + Condvar carrying Option<ExitReason>.
-    Condvar(Arc<(Mutex<Option<ExitReason>>, Condvar)>),
+    Threads(Arc<(Mutex<Option<ExitReason>>, Condvar)>),
 }
 
 // ---------------------------------------------------------------------------
@@ -78,7 +78,7 @@ impl ChildHandle {
         Self {
             id,
             cancel: Arc::new(move || cancellation_token.cancel()),
-            completion: Completion::Watch(completion_rx),
+            completion: Completion::Tasks(completion_rx),
         }
     }
 
@@ -91,7 +91,7 @@ impl ChildHandle {
         Self {
             id,
             cancel: Arc::new(move || cancellation_token.cancel()),
-            completion: Completion::Condvar(completion),
+            completion: Completion::Threads(completion),
         }
     }
 
@@ -114,8 +114,8 @@ impl ChildHandle {
     /// Poll the exit reason. Returns `None` if the actor is still running.
     pub fn exit_reason(&self) -> Option<ExitReason> {
         match &self.completion {
-            Completion::Watch(rx) => rx.borrow().clone(),
-            Completion::Condvar(completion) => {
+            Completion::Tasks(rx) => rx.borrow().clone(),
+            Completion::Threads(completion) => {
                 let (lock, _) = &**completion;
                 let guard = lock.lock().unwrap_or_else(|p| p.into_inner());
                 guard.clone()
@@ -138,12 +138,11 @@ impl ChildHandle {
     /// [`wait_exit_async`]: ChildHandle::wait_exit_async
     pub fn wait_exit_blocking(&self) -> ExitReason {
         match &self.completion {
-            Completion::Watch(rx) => {
-                // wait_for_exit_watch_blocking is extracted to avoid holding the
-                // borrow on self across the loop
-                wait_for_exit_watch_blocking(&rx.clone())
+            Completion::Tasks(rx) => {
+                // Extracted to avoid holding the borrow on self across the loop
+                wait_for_tasks_exit_blocking(&rx.clone())
             }
-            Completion::Condvar(completion) => {
+            Completion::Threads(completion) => {
                 let (lock, cvar) = &**completion;
                 let mut guard = lock.lock().unwrap_or_else(|p| p.into_inner());
                 loop {
@@ -158,15 +157,15 @@ impl ChildHandle {
 
     /// Async wait until the actor stops and return the exit reason.
     ///
-    /// Works with both execution modes. For Watch (tasks-mode handles), awaits
-    /// the watch channel directly. For Condvar (threads-mode handles), delegates
-    /// to a blocking task via `spawn_blocking` to avoid blocking the async runtime.
+    /// Works with both execution modes. For tasks-mode handles, awaits the
+    /// watch channel directly. For threads-mode handles, delegates to a
+    /// blocking task via `spawn_blocking` to avoid blocking the async runtime.
     ///
     /// **Note:** When used with threads-mode handles, this consumes a thread from
     /// tokio's blocking pool for the duration of the wait.
     pub async fn wait_exit_async(&self) -> ExitReason {
         match &self.completion {
-            Completion::Watch(rx) => {
+            Completion::Tasks(rx) => {
                 let mut rx = rx.clone();
                 loop {
                     if let Some(reason) = rx.borrow_and_update().clone() {
@@ -177,7 +176,7 @@ impl ChildHandle {
                     }
                 }
             }
-            Completion::Condvar(_) => {
+            Completion::Threads(_) => {
                 let handle = self.clone();
                 spawned_rt::tasks::spawn_blocking(move || handle.wait_exit_blocking())
                     .await
@@ -187,7 +186,7 @@ impl ChildHandle {
     }
 }
 
-/// Blocking wait on a watch channel.
+/// Blocking wait on a tasks-mode watch channel.
 ///
 /// - From a sync context (no tokio runtime): creates a temporary runtime.
 /// - From a multi-thread tokio runtime: uses `block_in_place` + `Handle::block_on`.
@@ -198,7 +197,7 @@ impl ChildHandle {
 /// Returns `ExitReason::Kill` if the watch sender is dropped without setting a
 /// reason — this means the actor task was aborted externally (e.g., runtime
 /// shutdown) without going through the normal exit path.
-fn wait_for_exit_watch_blocking(
+fn wait_for_tasks_exit_blocking(
     rx: &spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
 ) -> ExitReason {
     // Fast path: already done — works from any context, no runtime needed
@@ -460,6 +459,99 @@ mod tests {
             // Now wait_exit_blocking takes the fast path
             let reason = handle.wait_exit_blocking();
             assert_eq!(reason, ExitReason::Normal);
+        });
+    }
+
+    // --- Panic observation tests ---
+
+    #[test]
+    fn child_handle_observes_panic_in_threads_actor() {
+        use crate::message::Message;
+        use crate::threads::actor::{Actor, ActorStart, Context, Handler};
+
+        struct Boomer;
+        struct Boom;
+        impl Message for Boom {
+            type Result = ();
+        }
+        impl Actor for Boomer {}
+        impl Handler<Boom> for Boomer {
+            fn handle(&mut self, _msg: Boom, _ctx: &Context<Self>) {
+                panic!("intentional panic in handler");
+            }
+        }
+
+        let actor = Boomer.start();
+        let handle = actor.child_handle();
+        let _ = actor.send(Boom);
+
+        let reason = handle.wait_exit_blocking();
+        match reason {
+            ExitReason::Panic(msg) => {
+                assert!(msg.contains("intentional panic in handler"), "got: {msg}");
+            }
+            other => panic!("expected Panic, got {other:?}"),
+        }
+        assert!(!handle.is_alive());
+    }
+
+    #[test]
+    fn child_handle_observes_panic_in_tasks_actor() {
+        use crate::message::Message;
+        use crate::tasks::actor::{Actor, ActorStart, Context, Handler};
+
+        struct Boomer;
+        struct Boom;
+        impl Message for Boom {
+            type Result = ();
+        }
+        impl Actor for Boomer {}
+        impl Handler<Boom> for Boomer {
+            async fn handle(&mut self, _msg: Boom, _ctx: &Context<Self>) {
+                panic!("intentional panic in handler");
+            }
+        }
+
+        let runtime = spawned_rt::tasks::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let actor = Boomer.start();
+            let handle = actor.child_handle();
+            let _ = actor.send(Boom);
+
+            let reason = handle.wait_exit_async().await;
+            match reason {
+                ExitReason::Panic(msg) => {
+                    assert!(msg.contains("intentional panic in handler"), "got: {msg}");
+                }
+                other => panic!("expected Panic, got {other:?}"),
+            }
+            assert!(!handle.is_alive());
+        });
+    }
+
+    #[test]
+    fn child_handle_observes_panic_in_started_callback() {
+        use crate::tasks::actor::{Actor, ActorStart, Context};
+
+        struct PanicStart;
+        impl Actor for PanicStart {
+            async fn started(&mut self, _ctx: &Context<Self>) {
+                panic!("intentional panic in started");
+            }
+        }
+
+        let runtime = spawned_rt::tasks::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let actor = PanicStart.start();
+            let handle = actor.child_handle();
+
+            let reason = handle.wait_exit_async().await;
+            match reason {
+                ExitReason::Panic(msg) => {
+                    assert!(msg.contains("intentional panic in started"), "got: {msg}");
+                }
+                other => panic!("expected Panic, got {other:?}"),
+            }
         });
     }
 }

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -1,0 +1,256 @@
+use crate::error::ExitReason;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+// ---------------------------------------------------------------------------
+// ActorId
+// ---------------------------------------------------------------------------
+
+static NEXT_ACTOR_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Unique identity for an actor instance. Used by monitors and links to
+/// identify actors without needing the concrete actor type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ActorId(u64);
+
+impl ActorId {
+    pub(crate) fn next() -> Self {
+        Self(NEXT_ACTOR_ID.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl std::fmt::Display for ActorId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ActorId({})", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Completion — abstraction over tasks/threads completion signals
+// ---------------------------------------------------------------------------
+
+/// Type-erased completion signal. Wraps the mode-specific completion mechanism
+/// so `ChildHandle` works uniformly across tasks and threads.
+#[derive(Clone)]
+pub(crate) enum Completion {
+    /// Tasks mode: watch channel carrying Option<ExitReason>.
+    Watch(spawned_rt::tasks::watch::Receiver<Option<ExitReason>>),
+    /// Threads mode: Mutex + Condvar carrying Option<ExitReason>.
+    Condvar(Arc<(Mutex<Option<ExitReason>>, Condvar)>),
+}
+
+// ---------------------------------------------------------------------------
+// ChildHandle
+// ---------------------------------------------------------------------------
+
+/// Type-erased cancel function. Wraps the mode-specific cancellation token.
+type CancelFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Type-erased handle to a running actor. Provides lifecycle operations
+/// (stop, liveness check, exit reason) without knowing the actor's concrete type.
+///
+/// Obtained via `ChildHandle::from(actor_ref)`.
+///
+/// Unlike `ActorRef<A>`, a `ChildHandle` cannot send messages — it only
+/// provides supervision-related operations (stop, wait, monitor, link).
+#[derive(Clone)]
+pub struct ChildHandle {
+    id: ActorId,
+    cancel: CancelFn,
+    completion: Completion,
+}
+
+impl std::fmt::Debug for ChildHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChildHandle")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ChildHandle {
+    /// Create a ChildHandle for tasks mode.
+    pub(crate) fn from_tasks(
+        id: ActorId,
+        cancellation_token: spawned_rt::tasks::CancellationToken,
+        completion_rx: spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
+    ) -> Self {
+        Self {
+            id,
+            cancel: Arc::new(move || cancellation_token.cancel()),
+            completion: Completion::Watch(completion_rx),
+        }
+    }
+
+    /// Create a ChildHandle for threads mode.
+    pub(crate) fn from_threads(
+        id: ActorId,
+        cancellation_token: spawned_rt::threads::CancellationToken,
+        completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
+    ) -> Self {
+        Self {
+            id,
+            cancel: Arc::new(move || cancellation_token.cancel()),
+            completion: Completion::Condvar(completion),
+        }
+    }
+
+    /// The actor's unique identity.
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
+    /// Signal the actor to stop. The actor will finish its current handler,
+    /// run `stopped()`, and exit.
+    pub fn stop(&self) {
+        (self.cancel)();
+    }
+
+    /// Returns `true` if the actor is still running.
+    pub fn is_alive(&self) -> bool {
+        self.exit_reason().is_none()
+    }
+
+    /// Poll the exit reason. Returns `None` if the actor is still running.
+    pub fn exit_reason(&self) -> Option<ExitReason> {
+        match &self.completion {
+            Completion::Watch(rx) => rx.borrow().clone(),
+            Completion::Condvar(completion) => {
+                let (lock, _) = &**completion;
+                let guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+                guard.clone()
+            }
+        }
+    }
+
+    /// Block until the actor stops and return the exit reason.
+    ///
+    /// **Warning:** In tasks mode, this blocks the calling thread (not async).
+    /// Use `wait_exit_async()` from async code instead.
+    pub fn wait_exit_blocking(&self) -> ExitReason {
+        match &self.completion {
+            Completion::Watch(rx) => {
+                let mut rx = rx.clone();
+                spawned_rt::threads::block_on(async move {
+                    loop {
+                        if let Some(reason) = rx.borrow_and_update().clone() {
+                            return reason;
+                        }
+                        if rx.changed().await.is_err() {
+                            return ExitReason::Kill;
+                        }
+                    }
+                })
+            }
+            Completion::Condvar(completion) => {
+                let (lock, cvar) = &**completion;
+                let mut guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+                loop {
+                    if let Some(reason) = guard.clone() {
+                        return reason;
+                    }
+                    guard = cvar.wait(guard).unwrap_or_else(|p| p.into_inner());
+                }
+            }
+        }
+    }
+
+    /// Async wait until the actor stops and return the exit reason.
+    /// Only usable from async code (tasks mode).
+    pub async fn wait_exit_async(&self) -> ExitReason {
+        match &self.completion {
+            Completion::Watch(rx) => {
+                let mut rx = rx.clone();
+                loop {
+                    if let Some(reason) = rx.borrow_and_update().clone() {
+                        return reason;
+                    }
+                    if rx.changed().await.is_err() {
+                        return ExitReason::Kill;
+                    }
+                }
+            }
+            Completion::Condvar(_) => {
+                // Fallback: spawn a blocking task to avoid blocking the async runtime
+                let handle = self.clone();
+                spawned_rt::tasks::spawn_blocking(move || handle.wait_exit_blocking())
+                    .await
+                    .unwrap_or(ExitReason::Kill)
+            }
+        }
+    }
+}
+
+impl PartialEq for ChildHandle {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ChildHandle {}
+
+impl std::hash::Hash for ChildHandle {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn actor_id_is_unique() {
+        let a = ActorId::next();
+        let b = ActorId::next();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn actor_id_display() {
+        let id = ActorId::next();
+        let s = format!("{id}");
+        assert!(s.starts_with("ActorId("));
+    }
+
+    #[test]
+    fn child_handle_from_threads_basics() {
+        let completion = Arc::new((Mutex::new(None), Condvar::new()));
+        let token = spawned_rt::threads::CancellationToken::new();
+        let handle = ChildHandle::from_threads(ActorId::next(), token, completion.clone());
+
+        assert!(handle.is_alive());
+        assert!(handle.exit_reason().is_none());
+
+        // Simulate actor completion
+        {
+            let (lock, cvar) = &*completion;
+            let mut guard = lock.lock().unwrap();
+            *guard = Some(ExitReason::Normal);
+            cvar.notify_all();
+        }
+
+        assert!(!handle.is_alive());
+        assert_eq!(handle.exit_reason(), Some(ExitReason::Normal));
+    }
+
+    #[test]
+    fn child_handle_stop() {
+        let completion = Arc::new((Mutex::new(None), Condvar::new()));
+        let token = spawned_rt::threads::CancellationToken::new();
+        assert!(!token.is_cancelled());
+        let handle = ChildHandle::from_threads(ActorId::next(), token.clone(), completion);
+        handle.stop();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn child_handle_equality_by_id() {
+        let completion = Arc::new((Mutex::new(None), Condvar::new()));
+        let token = spawned_rt::threads::CancellationToken::new();
+        let id = ActorId::next();
+        let h1 = ChildHandle::from_threads(id, token.clone(), completion.clone());
+        let h2 = ChildHandle::from_threads(id, token, completion);
+        assert_eq!(h1, h2);
+    }
+}

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -123,24 +123,17 @@ impl ChildHandle {
         }
     }
 
-    /// Block until the actor stops and return the exit reason.
+    /// Block the calling thread until the actor stops and return the exit reason.
     ///
-    /// **Warning:** In tasks mode, this blocks the calling thread (not async).
-    /// Use `wait_exit_async()` from async code instead.
+    /// Safe to call from any context (sync or async). For the Watch variant,
+    /// uses the watch channel's built-in blocking recv. For Condvar, blocks
+    /// on the condvar directly.
     pub fn wait_exit_blocking(&self) -> ExitReason {
         match &self.completion {
             Completion::Watch(rx) => {
-                let mut rx = rx.clone();
-                spawned_rt::threads::block_on(async move {
-                    loop {
-                        if let Some(reason) = rx.borrow_and_update().clone() {
-                            return reason;
-                        }
-                        if rx.changed().await.is_err() {
-                            return ExitReason::Kill;
-                        }
-                    }
-                })
+                // wait_for_exit_watch_blocking is extracted to avoid holding the
+                // borrow on self across the loop
+                wait_for_exit_watch_blocking(&rx.clone())
             }
             Completion::Condvar(completion) => {
                 let (lock, cvar) = &**completion;
@@ -156,7 +149,10 @@ impl ChildHandle {
     }
 
     /// Async wait until the actor stops and return the exit reason.
-    /// Only usable from async code (tasks mode).
+    ///
+    /// Works with both execution modes. For Watch (tasks-mode handles), awaits
+    /// the watch channel directly. For Condvar (threads-mode handles), delegates
+    /// to a blocking task via `spawn_blocking` to avoid blocking the async runtime.
     pub async fn wait_exit_async(&self) -> ExitReason {
         match &self.completion {
             Completion::Watch(rx) => {
@@ -171,13 +167,43 @@ impl ChildHandle {
                 }
             }
             Completion::Condvar(_) => {
-                // Fallback: spawn a blocking task to avoid blocking the async runtime
                 let handle = self.clone();
                 spawned_rt::tasks::spawn_blocking(move || handle.wait_exit_blocking())
                     .await
                     .unwrap_or(ExitReason::Kill)
             }
         }
+    }
+}
+
+/// Blocking wait on a watch channel. Uses `block_in_place` if inside a tokio
+/// runtime (safe from multi-threaded runtime), otherwise creates a temporary runtime.
+fn wait_for_exit_watch_blocking(
+    rx: &spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
+) -> ExitReason {
+    // Fast path: already done
+    if let Some(reason) = rx.borrow().clone() {
+        return reason;
+    }
+
+    let mut rx = rx.clone();
+    let wait = async move {
+        loop {
+            if let Some(reason) = rx.borrow_and_update().clone() {
+                return reason;
+            }
+            if rx.changed().await.is_err() {
+                return ExitReason::Kill;
+            }
+        }
+    };
+
+    // If inside a tokio runtime, use block_in_place + block_on to avoid
+    // "cannot start a runtime from within a runtime" panic.
+    if let Ok(handle) = spawned_rt::tasks::Handle::try_current() {
+        spawned_rt::tasks::block_in_place(|| handle.block_on(wait))
+    } else {
+        spawned_rt::threads::block_on(wait)
     }
 }
 
@@ -252,5 +278,109 @@ mod tests {
         let h1 = ChildHandle::from_threads(id, token.clone(), completion.clone());
         let h2 = ChildHandle::from_threads(id, token, completion);
         assert_eq!(h1, h2);
+    }
+
+    // --- Integration tests using real actors ---
+
+    #[test]
+    fn child_handle_from_threads_actor_ref() {
+        use crate::message::Message;
+        use crate::threads::actor::{Actor, ActorStart, Context, Handler};
+
+        struct Worker;
+        struct Stop;
+        impl Message for Stop {
+            type Result = ();
+        }
+        impl Actor for Worker {}
+        impl Handler<Stop> for Worker {
+            fn handle(&mut self, _msg: Stop, ctx: &Context<Self>) {
+                ctx.stop();
+            }
+        }
+
+        let actor = Worker.start();
+        let handle = actor.child_handle();
+
+        assert!(handle.is_alive());
+        assert!(handle.exit_reason().is_none());
+        assert_eq!(handle.id(), actor.id());
+
+        actor.send(Stop).unwrap();
+        let reason = handle.wait_exit_blocking();
+        assert_eq!(reason, ExitReason::Normal);
+        assert!(!handle.is_alive());
+    }
+
+    #[test]
+    fn child_handle_from_tasks_actor_ref() {
+        use crate::message::Message;
+        use crate::tasks::actor::{Actor, ActorStart, Context, Handler};
+
+        struct Worker;
+        struct Stop;
+        impl Message for Stop {
+            type Result = ();
+        }
+        impl Actor for Worker {}
+        impl Handler<Stop> for Worker {
+            async fn handle(&mut self, _msg: Stop, ctx: &Context<Self>) {
+                ctx.stop();
+            }
+        }
+
+        let runtime = spawned_rt::tasks::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let actor = Worker.start();
+            let handle = actor.child_handle();
+
+            assert!(handle.is_alive());
+            assert!(handle.exit_reason().is_none());
+            assert_eq!(handle.id(), actor.id());
+
+            actor.send(Stop).unwrap();
+            let reason = handle.wait_exit_async().await;
+            assert_eq!(reason, ExitReason::Normal);
+            assert!(!handle.is_alive());
+        });
+    }
+
+    #[test]
+    fn child_handle_stop_from_tasks_actor() {
+        use crate::tasks::actor::{Actor, ActorStart};
+
+        struct Idler;
+        impl Actor for Idler {}
+
+        let runtime = spawned_rt::tasks::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let actor = Idler.start();
+            let handle = actor.child_handle();
+
+            assert!(handle.is_alive());
+            handle.stop();
+            let reason = handle.wait_exit_async().await;
+            assert_eq!(reason, ExitReason::Normal);
+        });
+    }
+
+    #[test]
+    fn child_handle_wait_blocking_inside_runtime() {
+        use crate::tasks::actor::{Actor, ActorStart};
+
+        struct Idler;
+        impl Actor for Idler {}
+
+        let runtime = spawned_rt::tasks::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let actor = Idler.start();
+            let handle = actor.child_handle();
+            handle.stop();
+
+            // This is the bug-fix test: wait_exit_blocking inside a tokio runtime
+            // should NOT panic (uses block_in_place internally)
+            let reason = spawned_rt::tasks::block_in_place(|| handle.wait_exit_blocking());
+            assert_eq!(reason, ExitReason::Normal);
+        });
     }
 }

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -52,7 +52,7 @@ type CancelFn = Arc<dyn Fn() + Send + Sync>;
 /// Obtained via `ChildHandle::from(actor_ref)`.
 ///
 /// Unlike `ActorRef<A>`, a `ChildHandle` cannot send messages — it only
-/// provides supervision-related operations (stop, wait, monitor, link).
+/// provides supervision-related operations (stop, wait, check liveness).
 #[derive(Clone)]
 pub struct ChildHandle {
     id: ActorId,
@@ -153,6 +153,9 @@ impl ChildHandle {
     /// Works with both execution modes. For Watch (tasks-mode handles), awaits
     /// the watch channel directly. For Condvar (threads-mode handles), delegates
     /// to a blocking task via `spawn_blocking` to avoid blocking the async runtime.
+    ///
+    /// **Note:** When used with threads-mode handles, this consumes a thread from
+    /// tokio's blocking pool for the duration of the wait.
     pub async fn wait_exit_async(&self) -> ExitReason {
         match &self.completion {
             Completion::Watch(rx) => {
@@ -178,6 +181,10 @@ impl ChildHandle {
 
 /// Blocking wait on a watch channel. Uses `block_in_place` if inside a tokio
 /// runtime (safe from multi-threaded runtime), otherwise creates a temporary runtime.
+///
+/// Returns `ExitReason::Kill` if the watch sender is dropped without setting a
+/// reason — this means the actor task was aborted externally (e.g., runtime
+/// shutdown) without going through the normal exit path.
 fn wait_for_exit_watch_blocking(
     rx: &spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
 ) -> ExitReason {

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -130,18 +130,15 @@ impl ChildHandle {
     /// - Multi-thread tokio runtime (uses `block_in_place`)
     /// - Threads-mode actors (uses Condvar directly)
     ///
-    /// **Panics** if called from within a current-thread tokio runtime on a
-    /// tasks-mode handle: blocking the only runtime thread would prevent the
-    /// actor task from making progress (deadlock). Use [`wait_exit_async`] from
-    /// async context instead.
+    /// **Panics** if called from within a non-multi-thread tokio runtime (e.g.,
+    /// current-thread) on a tasks-mode handle: blocking the only runtime thread
+    /// would prevent the actor task from making progress (deadlock). Use
+    /// [`wait_exit_async`] from async context instead.
     ///
     /// [`wait_exit_async`]: ChildHandle::wait_exit_async
     pub fn wait_exit_blocking(&self) -> ExitReason {
         match &self.completion {
-            Completion::Tasks(rx) => {
-                // Extracted to avoid holding the borrow on self across the loop
-                wait_for_tasks_exit_blocking(&rx.clone())
-            }
+            Completion::Tasks(rx) => wait_for_tasks_exit_blocking(rx.clone()),
             Completion::Threads(completion) => {
                 let (lock, cvar) = &**completion;
                 let mut guard = lock.lock().unwrap_or_else(|p| p.into_inner());
@@ -190,22 +187,22 @@ impl ChildHandle {
 ///
 /// - From a sync context (no tokio runtime): creates a temporary runtime.
 /// - From a multi-thread tokio runtime: uses `block_in_place` + `Handle::block_on`.
-/// - From a current-thread tokio runtime: **panics**, because blocking the only
-///   runtime thread prevents the actor task from making progress (deadlock).
-///   Use `wait_exit_async` from async context, or run on a multi-thread runtime.
+/// - From any other tokio runtime flavor (e.g., current-thread): **panics**,
+///   because blocking the only runtime thread prevents the actor task from
+///   making progress (deadlock). Use `wait_exit_async` from async context, or
+///   run on a multi-thread runtime.
 ///
 /// Returns `ExitReason::Kill` if the watch sender is dropped without setting a
 /// reason — this means the actor task was aborted externally (e.g., runtime
 /// shutdown) without going through the normal exit path.
 fn wait_for_tasks_exit_blocking(
-    rx: &spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
+    mut rx: spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
 ) -> ExitReason {
     // Fast path: already done — works from any context, no runtime needed
     if let Some(reason) = rx.borrow().clone() {
         return reason;
     }
 
-    let mut rx = rx.clone();
     let wait = async move {
         loop {
             if let Some(reason) = rx.borrow_and_update().clone() {
@@ -225,14 +222,15 @@ fn wait_for_tasks_exit_blocking(
             spawned_rt::tasks::RuntimeFlavor::MultiThread => {
                 spawned_rt::tasks::block_in_place(|| handle.block_on(wait))
             }
-            // CurrentThread runtime: blocking here would deadlock the actor task.
-            // Including future flavors (e.g., MultiThreadAlt) for safety — only
-            // MultiThread is known to be safe with block_in_place.
-            _ => panic!(
+            // Any other flavor (current-thread, MultiThreadAlt, future variants):
+            // blocking here would deadlock the actor task. RuntimeFlavor is
+            // #[non_exhaustive] so we conservatively reject anything other than
+            // the explicitly-tested MultiThread variant.
+            other => panic!(
                 "ChildHandle::wait_exit_blocking() cannot be called from within a \
-                current_thread tokio runtime; doing so would deadlock the actor \
-                task that this call is waiting for. Use wait_exit_async() from \
-                async context instead, or run on a multi-thread runtime."
+                non-multi-thread tokio runtime ({other:?}); doing so would deadlock \
+                the actor task that this call is waiting for. Use wait_exit_async() \
+                from async context instead, or run on a multi-thread runtime."
             ),
         },
     }
@@ -255,6 +253,14 @@ impl std::hash::Hash for ChildHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Shared tasks-mode fixture: an Idler actor that does nothing and never
+    // stops on its own. Used by multiple tests below.
+    mod tasks_fixtures {
+        use crate::tasks::actor::Actor;
+        pub struct Idler;
+        impl Actor for Idler {}
+    }
 
     #[test]
     fn actor_id_is_unique() {
@@ -378,10 +384,8 @@ mod tests {
 
     #[test]
     fn child_handle_stop_from_tasks_actor() {
-        use crate::tasks::actor::{Actor, ActorStart};
-
-        struct Idler;
-        impl Actor for Idler {}
+        use crate::tasks::actor::ActorStart;
+        use tasks_fixtures::Idler;
 
         let runtime = spawned_rt::tasks::Runtime::new().unwrap();
         runtime.block_on(async {
@@ -397,10 +401,8 @@ mod tests {
 
     #[test]
     fn child_handle_wait_blocking_inside_multithread_runtime() {
-        use crate::tasks::actor::{Actor, ActorStart};
-
-        struct Idler;
-        impl Actor for Idler {}
+        use crate::tasks::actor::ActorStart;
+        use tasks_fixtures::Idler;
 
         // Multi-thread runtime — wait_exit_blocking should work via block_in_place
         let runtime = spawned_rt::tasks::Runtime::new().unwrap();
@@ -415,12 +417,10 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "current_thread tokio runtime")]
+    #[should_panic(expected = "non-multi-thread tokio runtime")]
     fn child_handle_wait_blocking_panics_on_current_thread_runtime() {
-        use crate::tasks::actor::{Actor, ActorStart};
-
-        struct Idler;
-        impl Actor for Idler {}
+        use crate::tasks::actor::ActorStart;
+        use tasks_fixtures::Idler;
 
         let runtime = ::tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -438,10 +438,8 @@ mod tests {
 
     #[test]
     fn child_handle_wait_blocking_fast_path_on_current_thread_runtime() {
-        use crate::tasks::actor::{Actor, ActorStart};
-
-        struct Idler;
-        impl Actor for Idler {}
+        use crate::tasks::actor::ActorStart;
+        use tasks_fixtures::Idler;
 
         let runtime = ::tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/concurrency/src/child_handle.rs
+++ b/concurrency/src/child_handle.rs
@@ -115,11 +115,11 @@ impl ChildHandle {
     pub fn exit_reason(&self) -> Option<ExitReason> {
         match &self.completion {
             Completion::Tasks(rx) => rx.borrow().clone(),
-            Completion::Threads(completion) => {
-                let (lock, _) = &**completion;
-                let guard = lock.lock().unwrap_or_else(|p| p.into_inner());
-                guard.clone()
-            }
+            Completion::Threads(completion) => completion
+                .0
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .clone(),
         }
     }
 
@@ -139,16 +139,7 @@ impl ChildHandle {
     pub fn wait_exit_blocking(&self) -> ExitReason {
         match &self.completion {
             Completion::Tasks(rx) => wait_for_tasks_exit_blocking(rx.clone()),
-            Completion::Threads(completion) => {
-                let (lock, cvar) = &**completion;
-                let mut guard = lock.lock().unwrap_or_else(|p| p.into_inner());
-                loop {
-                    if let Some(reason) = guard.clone() {
-                        return reason;
-                    }
-                    guard = cvar.wait(guard).unwrap_or_else(|p| p.into_inner());
-                }
-            }
+            Completion::Threads(completion) => wait_for_threads_exit_blocking(completion),
         }
     }
 
@@ -162,17 +153,7 @@ impl ChildHandle {
     /// tokio's blocking pool for the duration of the wait.
     pub async fn wait_exit_async(&self) -> ExitReason {
         match &self.completion {
-            Completion::Tasks(rx) => {
-                let mut rx = rx.clone();
-                loop {
-                    if let Some(reason) = rx.borrow_and_update().clone() {
-                        return reason;
-                    }
-                    if rx.changed().await.is_err() {
-                        return ExitReason::Kill;
-                    }
-                }
-            }
+            Completion::Tasks(rx) => wait_loop(rx.clone()).await,
             Completion::Threads(_) => {
                 let handle = self.clone();
                 spawned_rt::tasks::spawn_blocking(move || handle.wait_exit_blocking())
@@ -180,6 +161,31 @@ impl ChildHandle {
                     .unwrap_or(ExitReason::Kill)
             }
         }
+    }
+}
+
+/// Async loop that polls a watch channel until it carries an exit reason.
+/// Returns `ExitReason::Kill` if the watch sender is dropped without a reason.
+async fn wait_loop(mut rx: spawned_rt::tasks::watch::Receiver<Option<ExitReason>>) -> ExitReason {
+    loop {
+        if let Some(reason) = rx.borrow_and_update().clone() {
+            return reason;
+        }
+        if rx.changed().await.is_err() {
+            return ExitReason::Kill;
+        }
+    }
+}
+
+/// Block the current thread on a Mutex+Condvar until it carries an exit reason.
+fn wait_for_threads_exit_blocking(completion: &(Mutex<Option<ExitReason>>, Condvar)) -> ExitReason {
+    let (lock, cvar) = completion;
+    let mut guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+    loop {
+        if let Some(reason) = guard.clone() {
+            return reason;
+        }
+        guard = cvar.wait(guard).unwrap_or_else(|p| p.into_inner());
     }
 }
 
@@ -196,23 +202,14 @@ impl ChildHandle {
 /// reason — this means the actor task was aborted externally (e.g., runtime
 /// shutdown) without going through the normal exit path.
 fn wait_for_tasks_exit_blocking(
-    mut rx: spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
+    rx: spawned_rt::tasks::watch::Receiver<Option<ExitReason>>,
 ) -> ExitReason {
     // Fast path: already done — works from any context, no runtime needed
     if let Some(reason) = rx.borrow().clone() {
         return reason;
     }
 
-    let wait = async move {
-        loop {
-            if let Some(reason) = rx.borrow_and_update().clone() {
-                return reason;
-            }
-            if rx.changed().await.is_err() {
-                return ExitReason::Kill;
-            }
-        }
-    };
+    let wait = wait_loop(rx);
 
     match spawned_rt::tasks::Handle::try_current() {
         // No active runtime — create a temporary one

--- a/concurrency/src/lib.rs
+++ b/concurrency/src/lib.rs
@@ -71,6 +71,7 @@
 //! - `Recipient<M>` (`Arc<dyn Receiver<M>>`) for type-erased per-message references
 //! - [`tasks::Backend`] enum for choosing async runtime, blocking pool, or OS thread
 
+pub mod child_handle;
 pub mod error;
 pub mod message;
 pub mod registry;
@@ -78,6 +79,7 @@ pub mod response;
 pub mod tasks;
 pub mod threads;
 
+pub use child_handle::{ActorId, ChildHandle};
 pub use error::{ActorError, ExitReason};
 pub use response::Response;
 pub use spawned_macros::{actor, protocol};

--- a/concurrency/src/tasks/actor.rs
+++ b/concurrency/src/tasks/actor.rs
@@ -1,3 +1,4 @@
+use crate::child_handle::{ActorId, ChildHandle};
 use crate::error::{panic_message, ActorError, ExitReason};
 use crate::message::Message;
 use core::pin::pin;
@@ -106,6 +107,7 @@ where
 ///
 /// Clone is cheap — it clones the inner channel sender and cancellation token.
 pub struct Context<A: Actor> {
+    id: ActorId,
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
     completion_rx: watch::Receiver<Option<ExitReason>>,
@@ -114,6 +116,7 @@ pub struct Context<A: Actor> {
 impl<A: Actor> Clone for Context<A> {
     fn clone(&self) -> Self {
         Self {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion_rx: self.completion_rx.clone(),
@@ -132,6 +135,7 @@ impl<A: Actor> Context<A> {
     /// or stream listeners from outside the actor.
     pub fn from_ref(actor_ref: &ActorRef<A>) -> Self {
         Self {
+            id: actor_ref.id,
             sender: actor_ref.sender.clone(),
             cancellation_token: actor_ref.cancellation_token.clone(),
             completion_rx: actor_ref.completion_rx.clone(),
@@ -211,6 +215,7 @@ impl<A: Actor> Context<A> {
     /// Get an `ActorRef<A>` from this context.
     pub fn actor_ref(&self) -> ActorRef<A> {
         ActorRef {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion_rx: self.completion_rx.clone(),
@@ -279,6 +284,7 @@ pub async fn request<M: Message>(
 /// To stop the actor, send an explicit shutdown message through your protocol,
 /// or call [`Context::stop`] from within a handler.
 pub struct ActorRef<A: Actor> {
+    id: ActorId,
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
     completion_rx: watch::Receiver<Option<ExitReason>>,
@@ -293,6 +299,7 @@ impl<A: Actor> Debug for ActorRef<A> {
 impl<A: Actor> Clone for ActorRef<A> {
     fn clone(&self) -> Self {
         Self {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion_rx: self.completion_rx.clone(),
@@ -391,6 +398,26 @@ impl<A: Actor> ActorRef<A> {
             }
         }
     }
+
+    /// The actor's unique identity.
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
+    /// Get a type-erased `ChildHandle` for this actor.
+    pub fn child_handle(&self) -> ChildHandle {
+        ChildHandle::from(self.clone())
+    }
+}
+
+impl<A: Actor> From<ActorRef<A>> for ChildHandle {
+    fn from(actor_ref: ActorRef<A>) -> Self {
+        ChildHandle::from_tasks(
+            actor_ref.id,
+            actor_ref.cancellation_token.clone(),
+            actor_ref.completion_rx.clone(),
+        )
+    }
 }
 
 // Bridge: ActorRef<A> implements Receiver<M> for any M that A handles
@@ -419,12 +446,14 @@ impl<A: Actor> ActorRef<A> {
         let (completion_tx, completion_rx) = watch::channel(None);
 
         let actor_ref = ActorRef {
+            id: ActorId::next(),
             sender: tx.clone(),
             cancellation_token: cancellation_token.clone(),
             completion_rx,
         };
 
         let ctx = Context {
+            id: actor_ref.id,
             sender: tx,
             cancellation_token: cancellation_token.clone(),
             completion_rx: actor_ref.completion_rx.clone(),

--- a/concurrency/src/tasks/actor.rs
+++ b/concurrency/src/tasks/actor.rs
@@ -142,6 +142,11 @@ impl<A: Actor> Context<A> {
         }
     }
 
+    /// The actor's unique identity.
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
     /// Signal the actor to stop. The current handler will finish, then
     /// `stopped()` is called and the actor exits.
     pub fn stop(&self) {
@@ -414,8 +419,8 @@ impl<A: Actor> From<ActorRef<A>> for ChildHandle {
     fn from(actor_ref: ActorRef<A>) -> Self {
         ChildHandle::from_tasks(
             actor_ref.id,
-            actor_ref.cancellation_token.clone(),
-            actor_ref.completion_rx.clone(),
+            actor_ref.cancellation_token,
+            actor_ref.completion_rx,
         )
     }
 }

--- a/concurrency/src/threads/actor.rs
+++ b/concurrency/src/threads/actor.rs
@@ -8,6 +8,7 @@ use std::{
     time::Duration,
 };
 
+use crate::child_handle::{ActorId, ChildHandle};
 use crate::error::{panic_message, ActorError, ExitReason};
 use crate::message::Message;
 
@@ -74,6 +75,7 @@ where
 ///
 /// Clone is cheap — it clones the inner channel sender and cancellation token.
 pub struct Context<A: Actor> {
+    id: ActorId,
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
     completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
@@ -82,6 +84,7 @@ pub struct Context<A: Actor> {
 impl<A: Actor> Clone for Context<A> {
     fn clone(&self) -> Self {
         Self {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion: self.completion.clone(),
@@ -100,6 +103,7 @@ impl<A: Actor> Context<A> {
     /// or stream listeners from outside the actor.
     pub fn from_ref(actor_ref: &ActorRef<A>) -> Self {
         Self {
+            id: actor_ref.id,
             sender: actor_ref.sender.clone(),
             cancellation_token: actor_ref.cancellation_token.clone(),
             completion: actor_ref.completion.clone(),
@@ -178,6 +182,7 @@ impl<A: Actor> Context<A> {
     /// Get an `ActorRef<A>` from this context.
     pub fn actor_ref(&self) -> ActorRef<A> {
         ActorRef {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion: self.completion.clone(),
@@ -261,6 +266,7 @@ impl Drop for CompletionGuard {
 /// To stop the actor, send an explicit shutdown message through your protocol,
 /// or call [`Context::stop`] from within a handler.
 pub struct ActorRef<A: Actor> {
+    id: ActorId,
     sender: mpsc::Sender<Box<dyn Envelope<A> + Send>>,
     cancellation_token: CancellationToken,
     completion: Arc<(Mutex<Option<ExitReason>>, Condvar)>,
@@ -275,6 +281,7 @@ impl<A: Actor> Debug for ActorRef<A> {
 impl<A: Actor> Clone for ActorRef<A> {
     fn clone(&self) -> Self {
         Self {
+            id: self.id,
             sender: self.sender.clone(),
             cancellation_token: self.cancellation_token.clone(),
             completion: self.completion.clone(),
@@ -373,6 +380,26 @@ impl<A: Actor> ActorRef<A> {
             completed = cvar.wait(completed).unwrap_or_else(|p| p.into_inner());
         }
     }
+
+    /// The actor's unique identity.
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
+    /// Get a type-erased `ChildHandle` for this actor.
+    pub fn child_handle(&self) -> ChildHandle {
+        ChildHandle::from(self.clone())
+    }
+}
+
+impl<A: Actor> From<ActorRef<A>> for ChildHandle {
+    fn from(actor_ref: ActorRef<A>) -> Self {
+        ChildHandle::from_threads(
+            actor_ref.id,
+            actor_ref.cancellation_token.clone(),
+            actor_ref.completion.clone(),
+        )
+    }
 }
 
 // Bridge: ActorRef<A> implements Receiver<M> for any M that A handles
@@ -399,14 +426,17 @@ impl<A: Actor> ActorRef<A> {
         let (tx, rx) = mpsc::channel::<Box<dyn Envelope<A> + Send>>();
         let cancellation_token = CancellationToken::new();
         let completion = Arc::new((Mutex::new(None), Condvar::new()));
+        let id = ActorId::next();
 
         let actor_ref = ActorRef {
+            id,
             sender: tx.clone(),
             cancellation_token: cancellation_token.clone(),
             completion: completion.clone(),
         };
 
         let ctx = Context {
+            id,
             sender: tx,
             cancellation_token: cancellation_token.clone(),
             completion: actor_ref.completion.clone(),

--- a/concurrency/src/threads/actor.rs
+++ b/concurrency/src/threads/actor.rs
@@ -110,6 +110,11 @@ impl<A: Actor> Context<A> {
         }
     }
 
+    /// The actor's unique identity.
+    pub fn id(&self) -> ActorId {
+        self.id
+    }
+
     /// Signal the actor to stop. The current handler will finish, then
     /// `stopped()` is called and the actor exits.
     pub fn stop(&self) {
@@ -396,8 +401,8 @@ impl<A: Actor> From<ActorRef<A>> for ChildHandle {
     fn from(actor_ref: ActorRef<A>) -> Self {
         ChildHandle::from_threads(
             actor_ref.id,
-            actor_ref.cancellation_token.clone(),
-            actor_ref.completion.clone(),
+            actor_ref.cancellation_token,
+            actor_ref.completion,
         )
     }
 }

--- a/examples/exit_reason/src/main.rs
+++ b/examples/exit_reason/src/main.rs
@@ -1,6 +1,6 @@
 use spawned_concurrency::protocol;
 use spawned_concurrency::tasks::{Actor, ActorStart, Context, Handler};
-use spawned_concurrency::Response;
+use spawned_concurrency::{ChildHandle, Response};
 use spawned_rt::tasks as rt;
 use std::time::Duration;
 
@@ -107,6 +107,50 @@ fn main() {
         worker4.stop().await.unwrap();
         worker4.join().await;
         println!("  After stop:   {:?}", worker4.exit_reason());
+
+        // 5. ChildHandle — type-erased supervision handle
+        println!("\n--- Scenario 5: ChildHandle ---");
+        let worker5 = Worker::new("worker-5").start();
+        let handle: ChildHandle = worker5.child_handle();
+        println!("  ActorId: {}", handle.id());
+        println!("  Same id as ActorRef: {}", handle.id() == worker5.id());
+        println!("  is_alive: {}", handle.is_alive());
+
+        // Stop via ChildHandle (type-erased, no message sending)
+        handle.stop();
+        let reason = handle.wait_exit_async().await;
+        println!("  Stopped via ChildHandle");
+        println!("  Exit reason: {reason}");
+        println!("  is_alive: {}", handle.is_alive());
+
+        // 6. ChildHandle from a panicking actor
+        println!("\n--- Scenario 6: ChildHandle observes panic ---");
+        let worker6 = Worker::new("worker-6").start();
+        let handle6 = worker6.child_handle();
+        let _ = worker6.panic_now().await;
+        let reason = handle6.wait_exit_async().await;
+        println!("  Exit reason: {reason}");
+        println!("  is_abnormal: {}", reason.is_abnormal());
+
+        // 7. Multiple ChildHandles from different actor types
+        println!("\n--- Scenario 7: Heterogeneous ChildHandle vec ---");
+        struct Idler;
+        impl Actor for Idler {}
+
+        let w = Worker::new("worker-7").start();
+        let i = Idler.start();
+        let handles: Vec<ChildHandle> = vec![w.child_handle(), i.child_handle()];
+        println!("  {} actors managed via Vec<ChildHandle>", handles.len());
+        for h in &handles {
+            println!("  {} — alive: {}", h.id(), h.is_alive());
+        }
+        for h in &handles {
+            h.stop();
+        }
+        for h in &handles {
+            let reason = h.wait_exit_async().await;
+            println!("  {} — exit: {reason}", h.id());
+        }
 
         // Give tracing a moment to flush
         rt::sleep(Duration::from_millis(50)).await;

--- a/rt/src/tasks/mod.rs
+++ b/rt/src/tasks/mod.rs
@@ -9,8 +9,6 @@
 
 mod tokio;
 
-use ::tokio::runtime::Handle;
-
 use crate::tracing::init_tracing;
 
 pub use crate::tasks::tokio::mpsc;
@@ -19,7 +17,9 @@ pub use crate::tasks::tokio::sleep;
 pub use crate::tasks::tokio::timeout;
 pub use crate::tasks::tokio::watch;
 pub use crate::tasks::tokio::CancellationToken;
-pub use crate::tasks::tokio::{spawn, spawn_blocking, task_id, JoinHandle, Runtime};
+pub use crate::tasks::tokio::{
+    block_in_place, spawn, spawn_blocking, task_id, Handle, JoinHandle, Runtime,
+};
 pub use crate::tasks::tokio::{BroadcastStream, ReceiverStream};
 use std::future::Future;
 
@@ -32,8 +32,15 @@ pub fn run<F: Future>(future: F) -> F::Output {
 }
 
 /// Block on a future using the current tokio runtime handle.
+/// Panics if no tokio runtime is active.
 pub fn block_on<F: Future>(future: F) -> F::Output {
     Handle::current().block_on(future)
+}
+
+/// Block on a future using the current tokio runtime handle.
+/// Returns `None` if no tokio runtime is active.
+pub fn try_block_on<F: Future>(future: F) -> Option<F::Output> {
+    Handle::try_current().ok().map(|h| h.block_on(future))
 }
 
 pub use crate::tasks::tokio::ctrl_c;

--- a/rt/src/tasks/mod.rs
+++ b/rt/src/tasks/mod.rs
@@ -18,7 +18,7 @@ pub use crate::tasks::tokio::timeout;
 pub use crate::tasks::tokio::watch;
 pub use crate::tasks::tokio::CancellationToken;
 pub use crate::tasks::tokio::{
-    block_in_place, spawn, spawn_blocking, task_id, Handle, JoinHandle, Runtime,
+    block_in_place, spawn, spawn_blocking, task_id, Handle, JoinHandle, Runtime, RuntimeFlavor,
 };
 pub use crate::tasks::tokio::{BroadcastStream, ReceiverStream};
 use std::future::Future;

--- a/rt/src/tasks/mod.rs
+++ b/rt/src/tasks/mod.rs
@@ -37,10 +37,4 @@ pub fn block_on<F: Future>(future: F) -> F::Output {
     Handle::current().block_on(future)
 }
 
-/// Block on a future using the current tokio runtime handle.
-/// Returns `None` if no tokio runtime is active.
-pub fn try_block_on<F: Future>(future: F) -> Option<F::Output> {
-    Handle::try_current().ok().map(|h| h.block_on(future))
-}
-
 pub use crate::tasks::tokio::ctrl_c;

--- a/rt/src/tasks/tokio/mod.rs
+++ b/rt/src/tasks/tokio/mod.rs
@@ -4,8 +4,8 @@ pub mod oneshot;
 pub use tokio::sync::watch;
 
 pub use tokio::{
-    runtime::Runtime,
-    task::{id as task_id, spawn, spawn_blocking, JoinHandle},
+    runtime::{Handle, Runtime},
+    task::{block_in_place, id as task_id, spawn, spawn_blocking, JoinHandle},
     time::{sleep, timeout},
 };
 pub use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream as ReceiverStream};

--- a/rt/src/tasks/tokio/mod.rs
+++ b/rt/src/tasks/tokio/mod.rs
@@ -4,7 +4,7 @@ pub mod oneshot;
 pub use tokio::sync::watch;
 
 pub use tokio::{
-    runtime::{Handle, Runtime},
+    runtime::{Handle, Runtime, RuntimeFlavor},
     task::{block_in_place, id as task_id, spawn, spawn_blocking, JoinHandle},
     time::{sleep, timeout},
 };


### PR DESCRIPTION
## Summary
- Adds `ActorId` — unique identity for actor instances, used by monitors and links to identify actors without knowing the concrete type
- Adds `ChildHandle` — type-erased handle to a running actor providing supervision operations (`stop()`, `is_alive()`, `exit_reason()`, `wait_exit_blocking()`, `wait_exit_async()`) without needing `ActorRef<A>`
- `From<ActorRef<A>> for ChildHandle` works in both tasks and threads modes
- `ActorRef<A>` and `Context<A>` now carry an `ActorId` assigned at spawn time, with `id()` accessors on both
- Extends `exit_reason` example with ChildHandle scenarios (type-erased stop, panic observation, heterogeneous `Vec<ChildHandle>`)

Building block for monitors (#131), links, and supervisor (#133). A supervisor manages children of different actor types — `ChildHandle` is how it holds and operates on them uniformly.

Key design decisions:
- `ActorId` fills the role of Erlang's Pid as a lightweight identity key, but is not the primary user-facing API (users interact through `ActorRef<A>` and `ChildHandle`)
- `CancelFn = Arc<dyn Fn() + Send + Sync>` wraps both tokio and threads-mode cancel tokens (they're different types)
- `Completion` enum with `Watch`/`Condvar` variants handles both execution modes
- `ChildHandle` equality is by `ActorId`, not pointer identity
- `wait_exit_blocking` uses `block_in_place` inside a tokio runtime to avoid panics

## Test plan
- [x] 9 new tests: ActorId uniqueness/display, ChildHandle basics/stop/equality, From<ActorRef> for both modes, wait_exit_blocking inside runtime
- [x] All 79 existing tests pass (no regressions)
- [x] Runnable example: `cargo run -p exit_reason` (scenarios 5-7 demonstrate ChildHandle)